### PR TITLE
'设置财务凭证部分，如果未审核则列表页面整行显示蓝色。'

### DIFF
--- a/finance/finance_view.xml
+++ b/finance/finance_view.xml
@@ -68,13 +68,14 @@
             <field name="name">voucher.tree</field>
             <field name="model">voucher</field>
             <field name="arch" type="xml">
-                <tree string="会计凭证">
+                <tree string="会计凭证" colors="blue:state == 'draft';">
                     <field name="document_word_id"/>
                     <field name="date"/>
                     <field name="name"/>
                     <field name="att_count"/>
                     <field name="period_id"/>
                     <field name="amount_text"/>
+                    <field name = "state" invisible="1" />
                 </tree>
             </field>
         </record>


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：

提交前:
未审核的会计凭证和审核完成的会计凭证不好区分。

提交后:
未审核的会计凭证和审核完成的会计凭证更容易区分。

--
我确认贡献此代码版权给Gooderp项目
