### PR TITLE
[IMP]finance 微小修正，凭证按时间逆序排列，分类和账户对应的科目标签修改

### DIFF
--- a/finance/finance.py
+++ b/finance/finance.py
@@ -31,6 +31,7 @@ MOUTH_SELECTION = [
 class voucher(models.Model):
     '''新建凭证'''
     _name = 'voucher'
+    _order = 'create_date desc'
 
     @api.one
     @api.depends('date')
@@ -265,9 +266,9 @@ class res_company(models.Model):
 
 class bank_account(models.Model):
     _inherit = 'bank.account'
-    account_id = fields.Many2one('finance.account', u'账户')
+    account_id = fields.Many2one('finance.account', u'科目')
 
 
 class core_category(models.Model):
     _inherit = 'core.category'
-    account_id = fields.Many2one('finance.account', u'账户')
+    account_id = fields.Many2one('finance.account', u'科目')


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---
科目叫账户会跟收付款账户混淆
凭证按id排序，新凭证在列表后面会计查起来不方便

提交前:
---
分类和账户上要求选择账户，逻辑混淆

提交后:
---
需要为分类和账户设置科目

--
我确认贡献此代码版权给Gooderp项目
