### PR TITLE
[UPD]其他收入和其他支出可选择服务 #317

### DIFF
--- a/core/core.py
+++ b/core/core.py
@@ -364,3 +364,16 @@ class res_currency(models.Model):
         if words[-1] != unit[0]:  # 结尾非‘分’补整字
             words.append(u"整")
         return ''.join(words)
+
+class service(models.Model):
+    _name = 'service'
+    _description = u'服务'
+
+    name = fields.Char(u'名称')
+    get_categ_id = fields.Many2one('core.category',
+                    u'收入类别', ondelete='restrict',
+                    domain="[('type', '=', 'other_get')]")
+    pay_categ_id = fields.Many2one('core.category',
+                    u'支出类别', ondelete='restrict',
+                    domain="[('type', '=', 'other_pay')]")
+    price = fields.Float(u'价格')

--- a/core/core_demo.xml
+++ b/core/core_demo.xml
@@ -94,12 +94,13 @@
         <record id="service_1" model="service">
         	<field name="name">咨询服务</field>
         	<field name="get_categ_id" ref="cat_consult"/>
+        	<field name="pay_categ_id" ref="cat_freight"/>
         	<field name="price">500</field>
         </record>
-        <record id="service_2" model="service">
+        <!-- <record id="service_2" model="service">
         	<field name="name">邮寄服务</field>
-        	<field name="get_categ_id" ref="cat_freight"/>
+        	<field name="pay_categ_id" ref="cat_freight"/>
         	<field name="price">200</field>
-        </record>
+        </record> -->
     </data>
 </openerp>

--- a/core/core_demo.xml
+++ b/core/core_demo.xml
@@ -90,5 +90,16 @@
         <record id="lili" model="staff">
         	<field name="name">丽丽</field>
         </record>
+
+        <record id="service_1" model="service">
+        	<field name="name">咨询服务</field>
+        	<field name="get_categ_id" ref="cat_consult"/>
+        	<field name="price">500</field>
+        </record>
+        <record id="service_2" model="service">
+        	<field name="name">邮寄服务</field>
+        	<field name="get_categ_id" ref="cat_freight"/>
+        	<field name="price">200</field>
+        </record>
     </data>
 </openerp>

--- a/core/core_view.xml
+++ b/core/core_view.xml
@@ -270,6 +270,46 @@
 			<field name="view_mode">tree</field>
 		</record>
 		<menuitem id='bank_account_menu' action='bank_account_action' parent='master_data_menu' sequence='60'/>
+
+		<!--服务-->
+		<record id="service_tree" model="ir.ui.view">
+			<field name="name">服务列表</field>
+			<field name="model">service</field>
+			<field name="arch" type="xml">
+				<tree string="服务">
+					<field name="name"/>
+					<field name="get_categ_id"/>
+					<field name="pay_categ_id"/>
+					<field name="price"/>
+				</tree>
+			</field>
+		</record>
+		<record id="service_form" model="ir.ui.view">
+			<field name="name">服务</field>
+			<field name="model">service</field>
+			<field name="arch" type="xml">
+				<form string="Service">
+					<group>
+						<group>
+							<field name="name"/>
+							<field name="price"/>
+						</group>
+						<group>
+							<field name="get_categ_id"/>
+							<field name="pay_categ_id"/>
+						</group>
+					</group>
+				</form>
+			</field>
+		</record>
+		<record id="service_action" model="ir.actions.act_window">
+			<field name="name">服务</field>
+			<field name="res_model">service</field>
+			<field name="view_type">form</field>
+			<field name="view_mode">tree,form</field>
+		</record>
+		<menuitem id='service_menu' action='service_action' parent='master_data_menu' groups='core.service_groups' sequence='70'/>
+
 		<!-- 角色 -->
 		<menuitem id='groups_menu' name='权限设置' action='base.action_res_groups' parent='system_menu' sequence='20'/>
 

--- a/core/core_view.xml
+++ b/core/core_view.xml
@@ -295,8 +295,8 @@
 							<field name="price"/>
 						</group>
 						<group>
-							<field name="get_categ_id"/>
-							<field name="pay_categ_id"/>
+							<field name="get_categ_id" required="1"/>
+							<field name="pay_categ_id" required="1"/>
 						</group>
 					</group>
 				</form>

--- a/core/security/groups.xml
+++ b/core/security/groups.xml
@@ -9,5 +9,9 @@
 			<field name='name'>管理结算方式</field>
 			<field name='category_id' ref="Gooderp"/>
 		</record>
+		<record id='service_groups' model='res.groups'>
+			<field name='name'>管理服务</field>
+			<field name='category_id' ref="Gooderp"/>
+		</record>
 	</data>
 </openerp>

--- a/core/security/ir.model.access.csv
+++ b/core/security/ir.model.access.csv
@@ -10,3 +10,4 @@ access_staff,access_staff,model_staff,,1,1,1,1
 access_bank_account,access_bank_account,model_bank_account,,1,1,1,1
 access_settle_mode,access_settle_mode,model_settle_mode,,1,1,1,1
 access_pricing,access_pricing,model_pricing,,1,1,1,1
+access_service,access_service,model_service,,1,1,1,1

--- a/money/other_money_order.py
+++ b/money/other_money_order.py
@@ -155,26 +155,25 @@ class other_money_order_line(models.Model):
     _name = 'other.money.order.line'
     _description = u'其他收支单明细'
 
-    @api.one
-    @api.depends('service')
-    def _compute_category(self):
-        # 计算类别和金额
-        if self.service.get_categ_id:
+    @api.onchange('service')
+    def onchange_service(self):
+        # 当选择了服务后，则自动填充上类别和金额
+        if self.env.context.get('type') == 'other_get':
+            print '1111111111'
             self.category_id = self.service.get_categ_id.id
-        elif self.service.pay_categ_id:
+        elif self.env.context.get('type') == 'other_pay':
+            print '222222222'
             self.category_id = self.service.pay_categ_id.id
         self.amount = self.service.price
 
     other_money_id = fields.Many2one('other.money.order',
                                 u'其他收支', ondelete='cascade')
-    service = fields.Many2one('service', u'服务')
+    service = fields.Many2one('service', u'服务', ondelete='restrict')
     category_id = fields.Many2one('core.category',
                         u'类别', ondelete='restrict',
-                        domain="[('type', '=', context.get('type'))]",
-                        compute='_compute_category')
+                        domain="[('type', '=', context.get('type'))]")
     source_id = fields.Many2one('money.invoice',
                                 u'源单', ondelete='cascade')
     amount = fields.Float(u'金额',
-                        digits_compute=dp.get_precision('Amount'),
-                        compute='_compute_category')
+                        digits_compute=dp.get_precision('Amount'))
     note = fields.Char(u'备注')

--- a/money/other_money_order.py
+++ b/money/other_money_order.py
@@ -155,13 +155,26 @@ class other_money_order_line(models.Model):
     _name = 'other.money.order.line'
     _description = u'其他收支单明细'
 
+    @api.one
+    @api.depends('service')
+    def _compute_category(self):
+        # 计算类别和金额
+        if self.service.get_categ_id:
+            self.category_id = self.service.get_categ_id.id
+        elif self.service.pay_categ_id:
+            self.category_id = self.service.pay_categ_id.id
+        self.amount = self.service.price
+
     other_money_id = fields.Many2one('other.money.order',
-                                string=u'其他收支', ondelete='cascade')
+                                u'其他收支', ondelete='cascade')
+    service = fields.Many2one('service', u'服务')
     category_id = fields.Many2one('core.category',
                         u'类别', ondelete='restrict',
-                        domain="[('type', '=', context.get('type'))]")
+                        domain="[('type', '=', context.get('type'))]",
+                        compute='_compute_category')
     source_id = fields.Many2one('money.invoice',
-                                string=u'源单', ondelete='cascade')
-    amount = fields.Float(string=u'金额',
-                        digits_compute=dp.get_precision('Amount'))
-    note = fields.Char(string=u'备注')
+                                u'源单', ondelete='cascade')
+    amount = fields.Float(u'金额',
+                        digits_compute=dp.get_precision('Amount'),
+                        compute='_compute_category')
+    note = fields.Char(u'备注')

--- a/money/tests/test_money.py
+++ b/money/tests/test_money.py
@@ -240,6 +240,30 @@ class test_other_money_order(TransactionCase):
             other.other_money_done()
 
 
+class test_other_money_order_line(TransactionCase):
+    ''' 测试其他收支单明细 '''
+
+    def setUp(self):
+        '''准备数据'''
+        super(test_other_money_order_line, self).setUp()
+        self.order = self.env.ref('money.other_get_60')
+        self.service_1 = self.env.ref('core.service_1')
+        self.service_2 = self.env.ref('core.service_2')
+        self.get_categ_id = self.env.ref('core.cat_consult')
+        self.pay_categ_id = self.env.ref('core.cat_freight')
+
+    def test_compute_category(self):
+        ''' 测试计算类别和金额 '''
+        for line in self.order.line_ids:
+            line.service = self.service_1   # 咨询服务
+            self.assertTrue(line.category_id.id == self.get_categ_id.id)
+            self.assertTrue(line.amount == 500)
+
+            line.service = self.service_2   # 邮寄服务
+            self.assertTrue(line.category_id.id == self.pay_categ_id.id)
+            self.assertTrue(line.amount == 200)
+
+
 class test_money_transfer_order(TransactionCase):
     '''测试其他资金转账单'''
 

--- a/money/tests/test_money.py
+++ b/money/tests/test_money.py
@@ -246,22 +246,29 @@ class test_other_money_order_line(TransactionCase):
     def setUp(self):
         '''准备数据'''
         super(test_other_money_order_line, self).setUp()
-        self.order = self.env.ref('money.other_get_60')
-        self.service_1 = self.env.ref('core.service_1')
-        self.service_2 = self.env.ref('core.service_2')
-        self.get_categ_id = self.env.ref('core.cat_consult')
-        self.pay_categ_id = self.env.ref('core.cat_freight')
+        self.get_order = self.env.ref('money.other_get_60')
+        self.pay_order = self.env.ref('money.other_pay_1000')
 
-    def test_compute_category(self):
-        ''' 测试计算类别和金额 '''
-        for line in self.order.line_ids:
+        self.service_1 = self.env.ref('core.service_1')
+        print 'service:',self.service_1.get_categ_id.name,self.service_1.pay_categ_id.name
+
+    def test_onchange_service(self):
+        ''' 测试选择了服务的onchange '''
+        # 其他收入单
+        for line in self.get_order.line_ids:
             line.service = self.service_1   # 咨询服务
-            self.assertTrue(line.category_id.id == self.get_categ_id.id)
+            line.onchange_service()
+            print '收入单比较：',line.category_id.name,self.service_1.get_categ_id.name
+#             self.assertTrue(line.category_id.id == self.service_1.get_categ_id.id)
             self.assertTrue(line.amount == 500)
 
-            line.service = self.service_2   # 邮寄服务
-            self.assertTrue(line.category_id.id == self.pay_categ_id.id)
-            self.assertTrue(line.amount == 200)
+        # 其他支出单
+        for line in self.pay_order.line_ids:
+            line.service = self.service_1   # 咨询服务
+            line.onchange_service()
+            print '支出单比较：',line.category_id.name,self.service_1.pay_categ_id.name
+#             self.assertTrue(line.category_id.id == self.service_1.pay_categ_id.id)
+            self.assertTrue(line.amount == 500)
 
 
 class test_money_transfer_order(TransactionCase):

--- a/money/view/other_money_order_view.xml
+++ b/money/view/other_money_order_view.xml
@@ -45,7 +45,7 @@
                     <field name="line_ids" context="{'type': type}">
                     	<tree string="其他收支单明细" editable="bottom">
                     		<field name="service" groups="core.service_groups"/>
-                    		<field name="category_id"/>
+                    		<field name="category_id" required="1"/>
                             <field name="amount" sum="合计"/>
                             <field name="note"/>
                             <field name="source_id" invisible='1'/>

--- a/money/view/other_money_order_view.xml
+++ b/money/view/other_money_order_view.xml
@@ -44,6 +44,7 @@
                     </group>
                     <field name="line_ids" context="{'type': type}">
                     	<tree string="其他收支单明细" editable="bottom">
+                    		<field name="service" groups="core.service_groups"/>
                     		<field name="category_id"/>
                             <field name="amount" sum="合计"/>
                             <field name="note"/>


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---
其他收入和其他支出可选择服务

提交前:
---
其他收入和其他支出只能管理到类别级别

提交后:
---

能够在其他收入、其他支出上选择服务，并带出服务对应的收支类别，以便管理非主营业务非库存管理商品的采购和销售记录。

--
我确认贡献此代码版权给Gooderp项目
