### PR TITLE
[FIX]联系人地址要拼接省市县，并且一个地址不能被多个联系人选到

### DIFF
--- a/province_city_county/partner_address.xml
+++ b/province_city_county/partner_address.xml
@@ -17,7 +17,7 @@
         				</group>
         			</group>
         			<group>
-                        <field name="detail_address"/>
+                        <field name="detail_address" required='1'/>
     				</group>
                 </form>
             </field>
@@ -91,7 +91,8 @@
 	                    	<field name="phone"/>
 	                    	<field name="qq"/>
 	                    	<field name="address_id" context="{
-	                    		'form_view_ref': 'province_city_county_form'}"/>
+	                    		'form_view_ref': 'province_city_county_form'}"
+	                    		domain="[('detail_address', '=', False)]"/>
 	                    	<field name="is_default_add"/>
 	                    </tree>
 	                </field>

--- a/province_city_county/province_city_county.py
+++ b/province_city_county/province_city_county.py
@@ -159,8 +159,8 @@ class partner(models.Model):
                 self.phone = child.phone
                 self.qq = child.qq
                 addr = child.address_id
-                address = (addr.province_id.name + addr.city_id.city_name
-                + addr.county_id.county_name + addr.detail_address)
+                address = (addr.province_id.name + addr.city_id.city_name +
+                           addr.county_id.county_name + addr.detail_address)
                 self.address = address
 
     child_ids = fields.One2many('partner.address', 'partner_id', u'业务伙伴地址')

--- a/province_city_county/province_city_county.py
+++ b/province_city_county/province_city_county.py
@@ -158,7 +158,10 @@ class partner(models.Model):
                 self.mobile = child.mobile
                 self.phone = child.phone
                 self.qq = child.qq
-                self.address = child.address_id.detail_address
+                addr = child.address_id
+                address = (addr.province_id.name + addr.city_id.city_name
+                + addr.county_id.county_name + addr.detail_address)
+                self.address = address
 
     child_ids = fields.One2many('partner.address', 'partner_id', u'业务伙伴地址')
     contact_people = fields.Char(u'联系人', compute='_compute_partner_address')

--- a/province_city_county/province_city_county.py
+++ b/province_city_county/province_city_county.py
@@ -158,9 +158,10 @@ class partner(models.Model):
                 self.mobile = child.mobile
                 self.phone = child.phone
                 self.qq = child.qq
-                addr = child.address_id
-                address = (addr.province_id.name + addr.city_id.city_name +
-                           addr.county_id.county_name + addr.detail_address)
+                address = (child.address_id.province_id.name +
+                           child.address_id.city_id.city_name +
+                           child.address_id.county_id.county_name +
+                           child.address_id.detail_address)
                 self.address = address
 
     child_ids = fields.One2many('partner.address', 'partner_id', u'业务伙伴地址')

--- a/province_city_county/province_city_county.py
+++ b/province_city_county/province_city_county.py
@@ -158,9 +158,9 @@ class partner(models.Model):
                 self.mobile = child.mobile
                 self.phone = child.phone
                 self.qq = child.qq
-                address = (child.address_id.province_id.name +
-                           child.address_id.city_id.city_name +
-                           child.address_id.county_id.county_name +
+                address = '%s%s%s%s' % (child.address_id.province_id.name,
+                           child.address_id.city_id.city_name,
+                           child.address_id.county_id.county_name,
                            child.address_id.detail_address)
                 self.address = address
 

--- a/province_city_county/province_city_county.py
+++ b/province_city_county/province_city_county.py
@@ -113,6 +113,17 @@ class province_city_county(models.Model):
             self.province_id = self.city_id.province_id.id
             return {'domain': {'county_id': [('city_id', '=', self.city_id.id)]}}
 
+    @api.multi
+    def name_get(self):
+        '''将省市县及详细地址拼接起来'''
+        res = []
+        for addr in self:
+            res.append((addr.id, u'%s%s%s%s' % (
+                addr.province_id.name, addr.city_id.city_name,
+                addr.county_id.county_name, addr.detail_address)))
+
+        return res
+
     city_id = fields.Many2one('all.city', u'市/区')
     county_id = fields.Many2one('all.county', u'县/市')
     province_id = fields.Many2one('country.state', u'省/市',

--- a/province_city_county/tests/test_city_county.py
+++ b/province_city_county/tests/test_city_county.py
@@ -157,6 +157,18 @@ class test_province_city_county(TransactionCase):
             child.address_id.county_id = county.id
             child.address_id.onchange_county()
 
+    def test_name_get(self):
+        '''测试将省市县及详细地址拼接起来'''
+        province = self.env['country.state'].search([('name', '=', u'上海市')])
+        city = self.env['all.city'].search([('city_name', '=', u'上海市')])
+        county = self.env['all.county'].search([('county_name', '=', u'徐汇区')])
+        for child in self.partner.child_ids:
+            child.address_id.province_id = province.id
+            child.address_id.city_id = city.id
+            child.address_id.county_id = county.id
+            child.address_id.detail_address = u'8888号'
+            child.address_id.name_get()
+
 class test_partner(TransactionCase):
 
     def setUp(self):


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---
联系人地址没有拼接省市县

提交前:
---
联系人地址只有详细地址，没有拼接省市县

提交后:
---
联系人地址拼接省市县和详细地址，并且一个地址不能被多个联系人选到

--
我确认贡献此代码版权给Gooderp项目