### PR TITLE
支持虚拟商品的销售

### DIFF
--- a/finance/trial_balance.xml
+++ b/finance/trial_balance.xml
@@ -16,8 +16,6 @@
                     <field name="current_occurrence_credit" sum="合计" merge="True" child_name='贷方'/>
                     <field name="cumulative_occurrence_debit" sum="合计"    base_string='期末余额' merge="False" child_name='借方' colspan='2'/>
                     <field name="cumulative_occurrence_credit" sum="合计" merge="True" child_name='贷方'/>
-                    <field name="ending_balance_debit" sum="合计"  merge="False"  base_string='本年累计发生额'  child_name='借方' colspan='2'/>
-                    <field name="ending_balance_credit" sum="合计" merge="True" child_name='贷方'/>
           		</tree>
             </field>
         </record>

--- a/goods/goods.py
+++ b/goods/goods.py
@@ -6,6 +6,7 @@ from openerp import models, fields, api
 class goods(models.Model):
     _inherit = 'goods'
 
+    no_stock = fields.Boolean(u'虚拟商品')
     using_batch = fields.Boolean(u'批号管理')
     force_batch_one = fields.Boolean(u'每批号数量为1')
     attribute_ids = fields.One2many('attribute', 'goods_id', string=u'属性')

--- a/goods/goods_demo.xml
+++ b/goods/goods_demo.xml
@@ -108,5 +108,18 @@
 			<field name="value_id" ref="goods.black"/>
 			<field name="category_id" ref="goods.attribute_color"/>
 		</record>
+
+		<!-- 虚拟商品 -->
+        <record id="diy" model="goods">
+            <field name="code">005</field>
+            <field name="name">装机</field>
+            <field name="category_id" ref="core.goods_category_1"/>
+            <field name="uom_id" ref="core.uom_set"/>
+            <field name="uos_id" ref="core.uom_set"/>
+            <field name="no_stock">True</field>
+            <field name="cost">20</field>
+            <field name="price">50</field>
+            <field name="conversion">1</field>
+        </record>
 	</data>
 </openerp>

--- a/goods/security/groups.xml
+++ b/goods/security/groups.xml
@@ -9,6 +9,10 @@
 			<field name='name'>管理批号</field>
 			<field name='category_id' ref="core.Gooderp"/>
 		</record>
+		<record id='no_stock_groups' model='res.groups'>
+            <field name='name'>管理虚拟商品</field>
+            <field name='category_id' ref="core.Gooderp"/>
+        </record>
 		<record id='batch_serial_groups' model='res.groups'>
 			<field name='name'>管理序列号</field>
 			<field name='implied_ids' eval="[(4,ref('goods.batch_groups'))]"/>

--- a/goods/view/goods_view.xml
+++ b/goods/view/goods_view.xml
@@ -51,6 +51,7 @@
                                         <field name='price'/>
 									</group>
 									<group>
+									    <field name='no_stock' groups='goods.no_stock_groups'/>
 										<field name='using_batch' groups='goods.batch_groups'/>
 										<field name='force_batch_one' attrs="{'invisible': [('using_batch', '=', False)]}"
 										groups='goods.batch_serial_groups' />

--- a/sell/tests/test_sell.py
+++ b/sell/tests/test_sell.py
@@ -386,6 +386,13 @@ class test_sell_delivery(TransactionCase):
         with self.assertRaises(except_orm):
             self.return_delivery.sell_delivery_done()
 
+    def test_no_stock(self):
+        ''' 测试虚拟商品出库 '''
+        delivery = self.delivery.copy()
+        for line in delivery.line_out_ids:
+            line.goods_id = self.env.ref('goods.diy')
+        delivery.sell_delivery_done()
+
     def test_scan_barcode(self):
         '''销售扫码出入库'''
         warehouse = self.env['wh.move']

--- a/warehouse/goods.py
+++ b/warehouse/goods.py
@@ -73,6 +73,8 @@ class goods(models.Model):
         return cost_unit * qty, cost_unit
 
     def is_using_matching(self):
+        if self.no_stock:
+            return False
         return True
 
     def is_using_batch(self):

--- a/warehouse/report/stock_balance.py
+++ b/warehouse/report/stock_balance.py
@@ -47,6 +47,7 @@ class report_stock_balance(models.Model):
                 WHERE line.qty_remaining > 0
                   AND wh.type = 'stock'
                   AND line.state = 'done'
+                  AND not goods.no_stock
 
                 GROUP BY wh.name, line.lot, attribute.name, goods.name, goods.id, uom.name, uos.name
 


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---
支持虚拟商品的销售和采购

提交前:
---
系统针对所有出库预先检查库存取成本，故无法销售虚拟产品如电子书、装机服务等不管理库存的销售过程

提交后:
---
增加组：管理虚拟商品

商品界面增加 虚拟商品 字段，勾选则为虚拟商品

虚拟商品出库时不检查库存可用数量

虚拟商品不在库存余额表中显示

虚拟商品也在收发明细表中显示

--
我确认贡献此代码版权给Gooderp项目