### PR TITLE
[Fix] #400 #401 采购应默认按入库结算

### DIFF
--- a/buy/buy.py
+++ b/buy/buy.py
@@ -86,7 +86,7 @@ class buy_order(models.Model):
     warehouse_dest_id = fields.Many2one('warehouse', u'调入仓库',
                                         default=_default_warehouse_dest,
                                         ondelete='restrict')
-    invoice_by_receipt=fields.Boolean(string=u"按收货结算")
+    invoice_by_receipt=fields.Boolean(string=u"按收货结算", default=True)
     line_ids = fields.One2many('buy.order.line', 'order_id', u'购货订单行',
                                states=READONLY_STATES, copy=True)
     note = fields.Text(u'备注')
@@ -484,7 +484,7 @@ class buy_receipt(models.Model):
     discount_rate = fields.Float(u'优惠率(%)', states=READONLY_STATES)
     discount_amount = fields.Float(u'优惠金额', states=READONLY_STATES,
                                    digits_compute=dp.get_precision('Amount'))
-    invoice_by_receipt=fields.Boolean(string=u"按收货结算")
+    invoice_by_receipt=fields.Boolean(string=u"按收货结算",default=True)
     amount = fields.Float(u'优惠后金额', compute=_compute_all_amount,
                           store=True, readonly=True,
                           digits_compute=dp.get_precision('Amount'))

--- a/buy/buy_view.xml
+++ b/buy/buy_view.xml
@@ -557,5 +557,7 @@
             parent="menu_buy_manage" sequence="2"/>
         <menuitem id="menu_buy_return" action="buy_return_action"
             parent="menu_buy_manage" sequence="3"/>
+        <menuitem id='buy_vendor_menu' action='core.vendor_action' name="供应商" parent='menu_buy_manage' sequence='10'/>
+		<menuitem id='buy_goods_menu' name='商品' parent='menu_buy_manage' action='goods.goods_action' sequence='20' />
 	</data>
 </openerp>

--- a/buy/security/groups.xml
+++ b/buy/security/groups.xml
@@ -6,6 +6,7 @@
 			<field name='name'>采购</field>
 			<field name='category_id' ref="core.Gooderp"/>
 			<field name="users" eval="[(4, ref('base.user_root'))]"/>
+			<field name="implied_ids" eval="[(4, ref('goods.view_cost_groups'))]"/>
 		</record>
 		<!--添加管理采购订单组-->
 		<record id='buy_groups' model='res.groups'>

--- a/core/core_view.xml
+++ b/core/core_view.xml
@@ -251,7 +251,7 @@
 		</record>
 		<menuitem id='vendor_menu' action='vendor_action' parent='master_data_menu' sequence='20'/>
 		<!--用户-->
-		<menuitem id='users_menu' name="用户" action='base.action_res_users' parent='master_data_menu' sequence='50' groups="base.erp_system"/>
+		<menuitem id='users_menu' name="用户" action='base.action_res_users' parent='master_data_menu' sequence='50' groups="base.group_system"/>
 		<!--账户-->
 		<record id="bank_account_tree" model="ir.ui.view">
 			<field name="name">bank.account.tree</field>

--- a/core/core_view.xml
+++ b/core/core_view.xml
@@ -251,7 +251,7 @@
 		</record>
 		<menuitem id='vendor_menu' action='vendor_action' parent='master_data_menu' sequence='20'/>
 		<!--用户-->
-		<menuitem id='users_menu' name="用户" action='base.action_res_users' parent='master_data_menu' sequence='50'/>
+		<menuitem id='users_menu' name="用户" action='base.action_res_users' parent='master_data_menu' sequence='50' groups="base.erp_system"/>
 		<!--账户-->
 		<record id="bank_account_tree" model="ir.ui.view">
 			<field name="name">bank.account.tree</field>

--- a/core/security/groups.xml
+++ b/core/security/groups.xml
@@ -6,8 +6,9 @@
 			<field name="name">Gooderp</field>
 		</record>
 		<record id='master_groups' model='res.groups'>
-			<field name='name'>主数据</field>
+			<field name='name'>配置</field>
 			<field name='category_id' ref="Gooderp"/>
+			<field name="users" eval="[(4, ref('base.user_root'))]"/>	    			
 		</record>
 		<record id='settle_mode_groups' model='res.groups'>
 			<field name='name'>管理结算方式</field>

--- a/finance/balance_sheet.py
+++ b/finance/balance_sheet.py
@@ -122,7 +122,6 @@ class create_balance_sheet_wizard(models.TransientModel):
 
     @api.multi
     def compute_profit(self, parameter_str, period_id, compute_field_list):
-        print "parameter_str,period_id,compute_field_list=",parameter_str,period_id,compute_field_list
         """ 根据传进来的 的科目的code 进行利润表的计算 """
         if parameter_str:
             parameter_str_list = parameter_str.split('~')

--- a/money/generate_accounting.py
+++ b/money/generate_accounting.py
@@ -108,14 +108,15 @@ class money_invoice(models.Model):
             raise except_orm(u'错误', u'请配置%s的会计科目' % (self.partner_id.name))
         if self.category_id.type == 'income':
             vals.update({'vouch_obj_id': vouch_obj.id, 'partner_credit': self.partner_id.id, 'name': self.name, 'string': u'源单',
-                         'amount': self.amount, 'credit_account_id': self.category_id.account_id.id, 'partner_debit': '',
+                         'amount': self.amount, 'credit_account_id': self.category_id.account_id.id, 'partner_debit': self.partner_id.id,
                          'debit_account_id': partner_account_id
                          })
 
         else:
             vals.update({'vouch_obj_id': vouch_obj.id, 'name': self.name, 'string': u'源单',
                          'amount': abs(self.amount), 'credit_account_id': partner_account_id,
-                         'debit_account_id': self.category_id.account_id.id, 'partner_credit': "", 'partner_debit': self.partner_id.id
+                         'debit_account_id': self.category_id.account_id.id, 'partner_debit': self.partner_id.id,
+                         'partner_credit':self.partner_id.id,
                          })
         self.create_voucher_line(vals)
         return res

--- a/money/view/go_live_order_view.xml
+++ b/money/view/go_live_order_view.xml
@@ -31,7 +31,7 @@
         </record>
 
 		<!--期初余额表 menu-->
-        <menuitem id="menu_money_go_live_action" action="go_live_order_action" parent="menu_money_report" sequence="5"/>
+        <menuitem id="menu_money_go_live_action" action="go_live_order_action" parent="menu_money_report" groups="base.group_system" sequence="5"/>
 	</data>
 </openerp>
 	

--- a/sell/sell_view.xml
+++ b/sell/sell_view.xml
@@ -548,5 +548,7 @@
 			parent='sell_order_menu_root' sequence='2'/>
 		<menuitem id="sell_return_menu" name='销售退货单' action="sell_return_action"
             parent="sell_order_menu_root" sequence="3"/>
+		<menuitem id='sell_customer_menu' action='core.customer_action' name="客户" parent='sell_order_menu_root' sequence='10'/>
+		<menuitem id='sell_goods_menu' name='商品' parent='sell_order_menu_root' action='goods.goods_action' sequence='20' />
     </data>
 </openerp>


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---
由于采购订单默认未选择按入库结算，粉刷匠发现付款时带不出入库单（对应的结算单），而且对账单里也没有此项

提交前:
---
采购订单和采购入库单默认按付款进度结算

提交后:
---
采购订单和采购入库单默认按收货结算

--
我确认贡献此代码版权给Gooderp项目
