### PR TITLE
[ADD] 更新期初输入方式

### DIFF
--- a/finance/data/finance_data.xml
+++ b/finance/data/finance_data.xml
@@ -739,6 +739,13 @@
             <field name='balance_directions'>in</field>
         </record>
 
+        <record id='account_init' model='finance.account'>
+            <field name='code'>9999</field>
+            <field name='name'>期初余额</field>
+            <field name='costs_types'>equity</field>
+            <field name='balance_directions'>in</field>
+        </record>
+
 
         <!-- 资产负债表-->
         <record id='bs_0' model='balance.sheet'>

--- a/money/other_money_order.py
+++ b/money/other_money_order.py
@@ -79,6 +79,7 @@ class other_money_order(models.Model):
     type = fields.Selection(TYPE_SELECTION, string=u'类型', readonly=True,
                             default=lambda self: self._context.get('type'),
                             states={'draft': [('readonly', False)]})
+    note = fields.Text(u'备注')
 
     @api.onchange('date')
     def onchange_date(self):

--- a/money/report/bank_statements.py
+++ b/money/report/bank_statements.py
@@ -72,7 +72,7 @@ class bank_statements_report(models.Model):
                         (CASE WHEN omo.type = 'other_pay' THEN omo.total_amount ELSE 0 END) AS pay,
                         0 AS balance,
                         omo.partner_id,
-                        NULL AS note
+                        omo.note AS note
                 FROM other_money_order AS omo
                 WHERE omo.state = 'done'
                 UNION ALL

--- a/money/view/other_money_order_view.xml
+++ b/money/view/other_money_order_view.xml
@@ -59,6 +59,7 @@
 		                	<field name="total_amount"/>
 		                </group>
 		            </group>
+                    <field name="note" placeholder="备注"/>
 		            <group>
 						<group>
 		                	<field name="create_date" string="录单时间" readonly="1"/>

--- a/money/view/partner_view.xml
+++ b/money/view/partner_view.xml
@@ -12,6 +12,25 @@
 				</field>
             </field>
         </record>
+        <!-- 增加期初字段 -->
+        <record id="customer_address_form" model="ir.ui.view">
+            <field name="model">partner</field>
+			<field name='inherit_id' ref='core.customer_address_form'/>
+            <field name="arch" type="xml">
+                <field name='receivable' position='after'>
+                	<field name='receivable_init' groups="base.group_erp_manager"/>
+                </field>
+            </field>
+        </record>
+        <record id="supplier_address_form" model="ir.ui.view">
+            <field name="model">partner</field>
+			<field name='inherit_id' ref='core.supplier_address_form'/>
+            <field name="arch" type="xml">
+                <field name='payable' position='after'>
+                	<field name='payable_init' groups="base.group_erp_manager"/>
+                </field>
+            </field>
+        </record>
 	</data>
 </openerp>
 	


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---
期初余额输入后可以生成凭证，并可被后续的收付款核销掉

提交前:
---
前一个版本删去了期初余额表的录入界面

提交后:
---

增加了期初余额科目，使用方法如下：

- 客户的界面增加 应收期初字段，输入后生成结算单和会计凭证，修改收入科目为期初科目后记账

- 供应商的界面增加 应付期初字段，输入后生成结算单和会计凭证，修改采购科目为期初科目后记账

- 新建一个其他收入类型叫资金期初，科目指向期初科目 资金账户的期初由其他收入方式录入

--
我确认贡献此代码版权给Gooderp项目
