### PR TITLE
[IMP]解决入库单和发货单审核时提示源库位和目标库位不能一样的错误

### DIFF
--- a/buy/buy_view.xml
+++ b/buy/buy_view.xml
@@ -495,7 +495,7 @@
             <field name="name">采购入库单</field>
             <field name="res_model">buy.receipt</field>
             <field name="view_mode">tree,form</field>
-            <field name="context">{'is_return':False, 'warehouse_dest_type': 'stock'}</field>
+            <field name="context">{'is_return':False, 'warehouse_type': 'supplier'}</field>
             <field name="domain">[('is_return','=',False)]</field>
             <field name="search_view_id" ref="buy_receipt_search"/>
             <field name="help" type="html">
@@ -509,7 +509,7 @@
             <field name="name">采购退货单</field>
             <field name="res_model">buy.receipt</field>
             <field name="view_mode">tree,form</field>
-            <field name="context">{'is_return':True, 'warehouse_type': 'stock'}</field>
+            <field name="context">{'is_return':True, 'warehouse_dest_type': 'supplier'}</field>
             <field name="domain">[('is_return','=',True)]</field>
             <field name="search_view_id" ref="buy_return_search"/>
             <field name="help" type="html">

--- a/warehouse/view/warehouse_view.xml
+++ b/warehouse/view/warehouse_view.xml
@@ -195,6 +195,7 @@
                             <group>
                                 <field name='type' required='1' attrs="{'readonly': [('state', '!=', 'draft')]}" />
                                 <field name='warehouse_id'/>
+                                <field name='warehouse_dest_id' invisible='1'/>
                             </group>
                         </group>
 
@@ -270,6 +271,7 @@
                             <group>
                                 <field name='type' required='1' attrs="{'readonly': [('state', '!=', 'draft')]}" />
                                 <field name='warehouse_dest_id'/>
+                                <field name='warehouse_id' invisible='1'/>
                             </group>
                         </group>
 

--- a/warehouse/warehouse_order.py
+++ b/warehouse/warehouse_order.py
@@ -108,7 +108,7 @@ class wh_in(models.Model):
     @api.multi
     @api.onchange('type')
     def onchange_type(self):
-        self.warehouse_id = self.env['warehouse'].get_warehouse_by_type(self.type)
+        self.warehouse_id = self.env['warehouse'].get_warehouse_by_type(self.type).id
 
 
 class wh_internal(osv.osv):


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---


提交前:
---
入库单和发货单审核时报错：源库位和目标库位不能一样

提交后:
---
入库单和发货单审核时正常

--
我确认贡献此代码版权给Gooderp项目
