### PR TITLE
[IMP]下拉时显示批次所在库位

### DIFF
--- a/warehouse/warehouse_move_line.py
+++ b/warehouse/warehouse_move_line.py
@@ -179,7 +179,7 @@ class wh_move_line(models.Model):
             domain.append(('lot',operator,name))
         records = self.search(domain,limit=limit)
         for line in records:
-            result.append((line.id, u'%s 余 %s' % (line.lot, line.qty_remaining)))
+            result.append((line.id, u'%s %s 余 %s' % (line.lot, line.warehouse_dest_id.name, line.qty_remaining)))
         return result
 
     def check_availability(self):


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---
下拉批次时显示仓库

由于批次下拉字段使用了parent.warehouse_id 作为条件，而这个条件有时不生效，导致非当前发货仓库的批次也可以下拉到，这样就给用户选择错误的机会。下拉时显示仓库虽然有些傻，但是避免出错。

提交前:
---
下拉批次时只显示批次和剩余数量

提交后:
---
显示 批次 仓库 剩余数量

--
我确认贡献此代码版权给Gooderp项目
