### PR TITLE
[IMP]调整采购和销售中单据下方排版，发货单上的地址和手机应为选择联系人（默认联系人在业务伙伴窗体中设置），然后自动带出地址和手机。

### DIFF
--- a/buy/buy_view.xml
+++ b/buy/buy_view.xml
@@ -129,20 +129,22 @@
 
                     <field name="note" placeholder="暂无备注信息"/>
                     <group>
-                        <group col="6" colspan="6">
+                        <group>
                             <field name="discount_rate" groups='buy.buy_discount_groups'/>
                             <field name="discount_amount" groups='buy.buy_discount_groups'/>
                             <field name="amount"/>
                         </group>
+                        <group>
+                        	<field name="prepayment" attrs="{'invisible': [('invoice_by_receipt','=',False)]}"/>
+                        	<field name="bank_account_id" attrs="{'invisible': [('invoice_by_receipt','=',False)]}"/>
+                        </group>
                     </group>
                     <group>
                         <group>
-                        	<field name="prepayment" attrs="{'invisible': [('invoice_by_receipt','=',False)]}"/>
                             <field name="create_uid" readonly="1" string="制单人"/>
                             <field name="approve_uid" readonly="1"/>
                         </group>
                     	<group>
-                    		<field name="bank_account_id" attrs="{'invisible': [('invoice_by_receipt','=',False)]}"/>
                             <field name="create_date" readonly="1" string="录单时间"/>
                             <field name="write_date" readonly="1" string="最后修改时间"/>
                         </group>
@@ -297,16 +299,14 @@
 		            </notebook>
                     <field name="note" placeholder="暂无备注信息" attrs="{'readonly': [('state','!=','draft')]}"/>
                     <group>
-                        <group col="8" colspan="8">
+                        <group>
                             <field name="discount_rate" groups='buy.buy_discount_groups' attrs="{'readonly': [('state','!=','draft')]}"/>
                             <field name="discount_amount" groups='buy.buy_discount_groups'/>
                             <field name="amount"/>
-                            <field name="payment" attrs="{'readonly': [('state','!=','draft')],
-                                                'invisible': [('invoice_by_receipt','=',False)]}"/>
                         </group>
-                    </group>
-                    <group>
-                        <group col="6" colspan="6">
+                        <group>
+                        	<field name="payment" attrs="{'readonly': [('state','!=','draft')],
+                                                'invisible': [('invoice_by_receipt','=',False)]}"/>
                             <field name="bank_account_id" attrs="{'readonly': [('state','!=','draft')],
                                                         'invisible': [('invoice_by_receipt','=',False)]}"/>
                             <field name="debt"/>
@@ -466,15 +466,13 @@
 		            </notebook>
                     <field name="note" placeholder="暂无备注信息" attrs="{'readonly': [('state','!=','draft')]}"/>
                     <group>
-                        <group col="8" colspan="8">
+                        <group>
                             <field name="discount_rate" groups='buy.buy_discount_groups' attrs="{'readonly': [('state','!=','draft')]}"/>
                             <field name="discount_amount" groups='buy.buy_discount_groups'/>
                             <field name="amount"/>
-                            <field name="payment" attrs="{'readonly': [('state','!=','draft')]}"/>
                         </group>
-                    </group>
-                    <group>
-                        <group col="6" colspan="6">
+                        <group>
+                        	<field name="payment" attrs="{'readonly': [('state','!=','draft')]}"/>
                             <field name="bank_account_id" attrs="{'readonly': [('state','!=','draft')]}"/>
                             <field name="debt"/>
                         </group>

--- a/partner_address/partner_address.py
+++ b/partner_address/partner_address.py
@@ -43,7 +43,7 @@ class partner_address(models.Model):
     _description = u'业务伙伴的联系人地址'
  
     partner_id = fields.Many2one('partner', u'业务伙伴')
-    contact_people = fields.Char(u'联系人')
+    contact = fields.Char(u'联系人')
     mobile = fields.Char(u'手机')
     phone = fields.Char(u'座机')
     qq = fields.Char(u'QQ/微信')
@@ -138,7 +138,7 @@ class partner(models.Model):
             return {}
         for child in self.child_ids:
             if child.is_default_add:
-                self.contact_people = child.contact_people
+                self.contact = child.contact
                 self.mobile = child.mobile
                 self.phone = child.phone
                 self.qq = child.qq
@@ -150,7 +150,7 @@ class partner(models.Model):
                 self.address = address
 
     child_ids = fields.One2many('partner.address', 'partner_id', u'业务伙伴地址')
-    contact_people = fields.Char(u'联系人', compute='_compute_partner_address')
+    contact = fields.Char(u'联系人', compute='_compute_partner_address')
     mobile = fields.Char(u'手机', compute='_compute_partner_address')
     phone = fields.Char(u'座机', compute='_compute_partner_address')
     qq = fields.Char(u'QQ/微信', compute='_compute_partner_address')

--- a/partner_address/partner_address.xml
+++ b/partner_address/partner_address.xml
@@ -8,7 +8,7 @@
             <field name='inherit_id' ref='core.customer_tree'/>
             <field name="arch" type="xml">
                 <field name="name" position="after">
-                	<field name="contact_people"/>
+                	<field name="contact"/>
                 	<field name="mobile"/>
                 	<field name="phone"/>
                 	<field name="qq"/>
@@ -26,7 +26,7 @@
                 <xpath expr="//group" position="after">
                     <field name="child_ids">
                     	<tree string="联系人地址" editable="bottom">
-	                    	<field name="contact_people"/>
+	                    	<field name="contact"/>
 	                    	<field name="mobile"/>
 	                    	<field name="phone"/>
 	                    	<field name="qq"/>
@@ -49,7 +49,7 @@
             <field name='inherit_id' ref='core.vendor_tree'/>
             <field name="arch" type="xml">
                 <field name="name" position="after">
-                	<field name="contact_people"/>
+                	<field name="contact"/>
                 	<field name="mobile"/>
                 	<field name="phone"/>
                 	<field name="qq"/>
@@ -67,7 +67,7 @@
                 <xpath expr="//group" position="after">
                     <field name="child_ids">
                     	<tree string="联系人地址" editable="bottom">
-	                    	<field name="contact_people" required="1"/>
+	                    	<field name="contact" required="1"/>
 	                    	<field name="mobile" required="1"/>
 	                    	<field name="phone"/>
 	                    	<field name="qq"/>

--- a/partner_address/tests/test_partner_address.py
+++ b/partner_address/tests/test_partner_address.py
@@ -15,7 +15,7 @@ class test_partner_address(TransactionCase):
                     [('id', '=', self.partner_id.id)])
         self.partner.write({'child_ids':
             [(0, 0,
-              {'contact_people': u'小东',
+              {'contact': u'小东',
                'mobile': '1385559999',
                }
             )]
@@ -177,7 +177,7 @@ class test_partner(TransactionCase):
         # 有联系人地址child_ids，并为默认地址时
         partner.write({'child_ids':
             [(0, 0,
-              {'contact_people': u'小东',
+              {'contact': u'小东',
                'province_id': self.province_id.id,
                'city_id': self.city_id.id,
                'county_id': self.county_id.id,
@@ -193,7 +193,7 @@ class test_partner(TransactionCase):
             child.is_default_add = True
 
         partner._compute_partner_address()
-        self.assertEqual(partner.contact_people, u'小东')
+        self.assertEqual(partner.contact, u'小东')
         self.assertEqual(partner.mobile, u'1385559999')
         self.assertEqual(partner.phone, u'55558888')
         self.assertEqual(partner.qq, u'11116666')

--- a/sell/sell.py
+++ b/sell/sell.py
@@ -52,6 +52,9 @@ class sell_order(models.Model):
 
     partner_id = fields.Many2one('partner', u'客户',
                             ondelete='restrict', states=READONLY_STATES)
+    contact = fields.Char(u'联系人', states=READONLY_STATES)
+    address = fields.Char(u'地址', states=READONLY_STATES)
+    mobile = fields.Char(u'手机', states=READONLY_STATES)
     staff_id = fields.Many2one('staff', u'销售员',
                             ondelete='restrict', states=READONLY_STATES)
     date = fields.Date(u'单据日期', states=READONLY_STATES,
@@ -91,6 +94,15 @@ class sell_order(models.Model):
                               store=True,
                               help=u"销货订单的发货状态", select=True, copy=False)
     cancelled = fields.Boolean(u'已终止')
+
+    @api.one
+    @api.onchange('partner_id')
+    def onchange_partner_id(self):
+        '''选择客户带出其默认地址信息'''
+        if self.partner_id:
+            self.contact = self.partner_id.contact
+            self.address = self.partner_id.address
+            self.mobile = self.partner_id.mobile
 
     @api.one
     @api.onchange('discount_rate', 'line_ids')
@@ -455,9 +467,19 @@ class sell_delivery(models.Model):
     return_state = fields.Char(u'退款状态', compute=_get_sell_return_state,
                                store=True, default=u'未退款',
                                help=u"销售退货单的退款状态", select=True, copy=False)
-    address = fields.Char(u'地址')
-    mobile = fields.Char(u'手机')
+    contact = fields.Char(u'联系人', states=READONLY_STATES)
+    address = fields.Char(u'地址', states=READONLY_STATES)
+    mobile = fields.Char(u'手机', states=READONLY_STATES)
     modifying = fields.Boolean(u'差错修改中', default=False)
+
+    @api.one
+    @api.onchange('partner_id')
+    def onchange_partner_id(self):
+        '''选择客户带出其默认地址信息'''
+        if self.partner_id:
+            self.contact = self.partner_id.contact
+            self.address = self.partner_id.address
+            self.mobile = self.partner_id.mobile
 
     @api.one
     @api.onchange('discount_rate', 'line_in_ids', 'line_out_ids')

--- a/sell/sell_view.xml
+++ b/sell/sell_view.xml
@@ -39,6 +39,9 @@
             					<field name='partner_id' required='1'
             						domain="[('c_category_id', '!=', False)]"
             						context="{'form_view_ref': 'core.customer_address_form'}"/>
+            					<field name='contact'/>
+            				    <field name='address'/>
+            				    <field name='mobile'/>
             					<field name='staff_id'/>
             					<field name='date'/>
             					<field name='warehouse_id'/>
@@ -75,24 +78,22 @@
 				 				</field>
 				 				<field name="note" placeholder="暂无备注信息"/>
 				 				<group>
-                        			<group col="6" colspan="6">
+                        			<group>
 										<field name="discount_rate" groups='sell.sell_discount_groups'/>
 										<field name="discount_amount" groups='sell.sell_discount_groups'/>
                             			<field name="amount"/>
                         			</group>
-                    			</group>
-                    			<group>
                         			<group>
 										<field name="pre_receipt"/>
-                        			</group>
-                        			<group>
                             			<field name="bank_account_id"/>
                         			</group>
                     			</group>
                     			<group>
-                        			<group col="8" colspan="2">
+                        			<group>
                             			<field name="create_uid" readonly="1" string="制单人"/>
                             			<field name="approve_uid" readonly="1"/>
+                            		</group>
+                        			<group>
                             			<field name="create_date" readonly="1" string="录单时间"/>
                             			<field name="write_date" readonly="1" string="最后修改时间"/>
                         			</group>
@@ -181,6 +182,7 @@
             						attrs="{'readonly': [('state','!=','draft')]}"
             						domain="[('c_category_id', '!=', False)]"
             						context="{'form_view_ref': 'core.customer_address_form'}"/>
+            				    <field name='contact'/>
             				    <field name="address"/>
             				    <field name="mobile"/>
             					<field name='staff_id' attrs="{'readonly': [('state','!=','draft')]}"/>
@@ -358,6 +360,9 @@
             						attrs="{'readonly': [('state','!=','draft')]}"
             						domain="[('c_category_id', '!=', False)]"
             						context="{'form_view_ref': 'core.customer_address_form'}"/>
+            					<field name='contact'/>
+            				    <field name="address"/>
+            				    <field name="mobile"/>
             					<field name='staff_id' attrs="{'readonly': [('state','!=','draft')]}"/>
             					<field name='date' attrs="{'readonly': [('state','!=','draft')]}"/>
             					<field name="warehouse_dest_id"/>

--- a/sell/tests/test_sell.py
+++ b/sell/tests/test_sell.py
@@ -184,6 +184,10 @@ class test_sell_order(TransactionCase):
              }).create({})
         self.assertTrue(order.warehouse_id.type == 'stock')
 
+    def test_onchange_partner_id(self):
+        '''选择客户带出其默认地址信息'''
+        self.order.onchange_partner_id()
+
     def test_unlink(self):
         '''测试删除已审核的销货订单'''
         self.order.sell_order_done()
@@ -300,6 +304,10 @@ class test_sell_delivery(TransactionCase):
 
         self.bank_account = self.env.ref('core.alipay')
         self.bank_account.balance = 10000
+
+    def test_onchange_partner_id(self):
+        '''选择客户带出其默认地址信息'''
+        self.delivery.onchange_partner_id()
 
     def test_get_sell_money_state(self):
         '''测试返回收款状态'''


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---


提交前:
---


提交后:
---


--
我确认贡献此代码版权给Gooderp项目
#504