### PR TITLE
[FIX]sell增加对partner_address的依赖

### DIFF
--- a/sell/__openerp__.py
+++ b/sell/__openerp__.py
@@ -24,7 +24,7 @@
     'author': 'jeff@osbzr.com,flora@osbzr.com',
     'website': 'https://www.osbzr.com',
     'description': '''gooderp销售实例，通过安装gooderp模块展示openerp的销售流程''',
-    'depends': ['mail', 'core', 'warehouse', 'money'],
+    'depends': ['mail', 'core', 'warehouse', 'money', 'partner_address'],
     'data': [
             'sell_data.xml',
             'security/groups.xml',


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---


提交前:
---

没安装partner_address时，销货订单上会报找不到contact属性
提交后:
---


--
我确认贡献此代码版权给Gooderp项目
