### PR TITLE
[ADD] 在商品上勾选‘每批号数量为1’;在采购入库单里有相同的几个商品输入同一个批号可以保存审核 #543

### DIFF
--- a/buy/buy.py
+++ b/buy/buy.py
@@ -608,7 +608,7 @@ class buy_receipt(models.Model):
                         batch_one_list_wh.append((move_line.goods_id.id, move_line.lot))
 
             if (line.goods_id.id, line.lot) in batch_one_list_wh:
-                raise except_orm(u'错误', u'仓库已存在相同批号的产品！')
+                raise except_orm(u'错误', u'仓库已存在相同序列号的产品！')
 
         for line in self.line_in_ids:
             if line.goods_qty <= 0 or line.price_taxed < 0:
@@ -617,7 +617,7 @@ class buy_receipt(models.Model):
                 batch_one_list.append((line.goods_id.id, line.lot))
 
         if len(batch_one_list) > len(set(batch_one_list)):
-            raise except_orm(u'错误', u'不能创建相同批号的产品！')
+            raise except_orm(u'错误', u'不能创建相同序列号的产品！')
 
         for line in self.line_out_ids:
             if line.goods_qty <= 0 or line.price_taxed < 0:

--- a/buy/buy.py
+++ b/buy/buy.py
@@ -598,9 +598,26 @@ class buy_receipt(models.Model):
     def _wrong_receipt_done(self):
         if self.state == 'done':
             raise except_orm(u'错误', u'请不要重复审核！')
+        batch_one_list_wh = []
+        batch_one_list = []
+        for line in self.line_in_ids:
+            if line.goods_id.force_batch_one:
+                wh_move_lines = self.env['wh.move.line'].search([('state', '=', 'done'), ('type', '=', 'in'), ('goods_id', '=', line.goods_id.id)])
+                for move_line in wh_move_lines:
+                    if (move_line.goods_id.id, move_line.lot) not in batch_one_list_wh and move_line.lot:
+                        batch_one_list_wh.append((move_line.goods_id.id, move_line.lot))
+
+            if (line.goods_id.id, line.lot) in batch_one_list_wh:
+                raise except_orm(u'错误', u'仓库已存在相同批号的产品！')
+
         for line in self.line_in_ids:
             if line.goods_qty <= 0 or line.price_taxed < 0:
                 raise except_orm(u'错误', u'产品 %s 的数量和含税单价不能小于0！' % line.goods_id.name)
+            if line.goods_id.force_batch_one:
+                batch_one_list.append((line.goods_id.id, line.lot))
+
+        if len(batch_one_list) > len(set(batch_one_list)):
+            raise except_orm(u'错误', u'不能创建相同批号的产品！')
 
         for line in self.line_out_ids:
             if line.goods_qty <= 0 or line.price_taxed < 0:

--- a/buy/tests/test_buy.py
+++ b/buy/tests/test_buy.py
@@ -381,6 +381,43 @@ class test_buy_receipt(TransactionCase):
             self.assertTrue(line.share_cost == 100)
             self.assertTrue(line.using_attribute)
 
+    def test_wrong_receipt_done_lot_unique_current(self):
+        '''审核时，当前入库单行之间同一产品批号不能相同'''
+        receipt = self.env['buy.receipt'].create({
+            'partner_id': self.env.ref('core.lenovo').id,
+            'date': '2016-09-01',
+            'date_due': '2016-09-05',
+            'warehouse_dest_id': self.env.ref('warehouse.bj_stock').id,
+            'line_in_ids': [
+                (0, 0, {
+                    'goods_id': self.env.ref('goods.mouse').id,
+                    'lot': 'lot_1',
+                    'goods_qty': 1.0}),
+                (0, 0, {
+                    'goods_id': self.env.ref('goods.mouse').id,
+                    'lot': 'lot_1',
+                    'goods_qty': 1.0})
+            ]
+        })
+        with self.assertRaises(except_orm):
+            receipt.buy_receipt_done()
+
+    def test_wrong_receipt_done_lot_unique_wh(self):
+        '''审核时，当前入库单行与仓库里同一产品批号不能相同'''
+        receipt = self.env['buy.receipt'].create({
+            'partner_id': self.env.ref('core.lenovo').id,
+            'date': '2016-09-01',
+            'date_due': '2016-09-05',
+            'warehouse_dest_id': self.env.ref('warehouse.bj_stock').id,
+            'line_in_ids': [(0, 0, {
+                'goods_id': self.env.ref('goods.mouse').id,
+                'lot': 'lot_1',
+                'goods_qty': 1.0,
+                'state': 'done'})]
+        })
+        with self.assertRaises(except_orm):
+            receipt.buy_receipt_done()
+
     def test_receipt_make_invoice(self):
         '''审核入库单：不勾按收货结算时'''
         self.order.buy_order_draft()

--- a/buy/tests/test_report.py
+++ b/buy/tests/test_report.py
@@ -76,8 +76,13 @@ class test_track_wizard(TransactionCase):
         order_2.buy_order_done()
         receipt_2 = self.env['buy.receipt'].search(
                     [('order_id', '=', order_2.id)])
+        line_lists = []
         for line in receipt_2.line_in_ids:
-            line.goods_qty = 5
+            if line.id not in line_lists:
+                line.lot = 'mouse_lot_' + str(line.id)
+                line.goods_qty = 5
+            line_lists.append(line.id)
+
         receipt_2.buy_receipt_done()
         receipt_3 = self.env['buy.receipt'].search(
                     [('order_id', '=', order_2.id), ('state', '=', 'draft')])

--- a/money/view/money_order_view.xml
+++ b/money/view/money_order_view.xml
@@ -238,7 +238,7 @@
         <menuitem id="menu_money_payment_action" action="money_payment_action" parent="menu_money_manage" sequence="2"/>
 		<!-- 源单menu -->
 		<menuitem id="menu_money_invoice_action" action="money_invoice_action"
-			parent="menu_money_manage" sequence="3"
+			name="结算单" parent="menu_money_manage" sequence="3"
 			groups='money.reconcile_groups'/>
 	</data>
 </openerp>


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---


提交前:
---


提交后:
---


--
我确认贡献此代码版权给Gooderp项目
