### PR TITLE
[FIX]解决只安装销售而不安装采购模块时发货单上选择产品带不出单价的bug

### DIFF
--- a/sell/sell.py
+++ b/sell/sell.py
@@ -870,6 +870,19 @@ class wh_move_line(models.Model):
             else:
                 self.discount_rate = 0
 
+    @api.multi
+    @api.onchange('goods_id')
+    def onchange_goods_id(self):
+        '''当订单行的产品变化时，带出产品上的零售价，以及公司的销项税'''
+        if self.goods_id:
+            is_return = self.env.context.get('default_is_return')
+            # 如果是销售发货单行 或 销售退货单行
+            if (self.type == 'out' and not is_return) or (self.type == 'in' and is_return):
+                self.tax_rate = self.env.user.company_id.output_tax_rate
+                self.price_taxed = self.goods_id.price
+
+        return super(wh_move_line,self).onchange_goods_id()
+
 class cost_line(models.Model):
     _inherit = 'cost.line'
 

--- a/sell/tests/test_sell.py
+++ b/sell/tests/test_sell.py
@@ -589,7 +589,7 @@ class test_wh_move_line(TransactionCase):
             self.assertTrue(line.discount_rate == 0)
 
     def test_onchange_goods_id(self):
-        '''测试采购模块中商品的onchange,是否会带出单价'''
+        '''测试销售模块中商品的onchange,是否会带出单价'''
         # 销售退货单
         for line in self.delivery_return.line_in_ids:
             line.with_context({'default_is_return': True,


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---


提交前:
---

只安装销售而不安装采购模块时发货单上选择产品   带不出单价
提交后:
---

只安装销售而不安装采购模块时发货单上选择产品   可以带出单价
--
我确认贡献此代码版权给Gooderp项目
