### PR TITLE
科目余额表生成错误，结算本月 把本月期初的数据生成的数据的期间写成上月 =-= (代码重构引起sorry)

### DIFF
--- a/finance/trial_balance.py
+++ b/finance/trial_balance.py
@@ -170,7 +170,7 @@ class CreateTrialBalanceWizard(models.TransientModel):
                 'cumulative_occurrence_credit': cumulative_occurrence_credit,
                 'cumulative_occurrence_debit': cumulative_occurrence_debit,
                 'subject_code': subject_code,
-                'period_id': last_period.id,
+                'period_id': self.period_id.id,
                 'subject_name_id': subject_name_id
             }
         return currency_dcit


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---


提交前:
---


提交后:
---


--
我确认贡献此代码版权给Gooderp项目
