### PR TITLE
[IMP]订单审核时生成销货单时，联系人、地址、电话从订单中获取,以及代码重构，以适合扩展算法

### DIFF
--- a/buy/models/buy_receipt.py
+++ b/buy/models/buy_receipt.py
@@ -401,6 +401,10 @@ class wh_move_line(models.Model):
                               digits=dp.get_precision('Amount'),
                               help=u'点击分摊按钮或审核时将采购费用进行分摊得出的费用')
 
+    def _buy_get_price_and_tax(self):
+        self.tax_rate = self.env.user.company_id.import_tax_rate
+        self.price_taxed = self.goods_id.cost
+
     @api.multi
     @api.onchange('goods_id', 'tax_rate')
     def onchange_goods_id(self):
@@ -413,7 +417,6 @@ class wh_move_line(models.Model):
             is_return = self.env.context.get('default_is_return')
             # 如果是采购入库单行 或 采购退货单行
             if (self.type == 'in' and not is_return) or (self.type == 'out' and is_return):
-                self.tax_rate = self.env.user.company_id.import_tax_rate
-                self.price_taxed = self.goods_id.cost
+                self._buy_get_price_and_tax()
 
         return super(wh_move_line,self).onchange_goods_id()

--- a/goods/goods.py
+++ b/goods/goods.py
@@ -11,7 +11,7 @@ class goods(models.Model):
     force_batch_one = fields.Boolean(u'每批号数量为1')
     attribute_ids = fields.One2many('attribute', 'goods_id', string=u'属性')
     image=fields.Binary(u'图片')
-    supplier_id = fields.Many2one('partner',u'供应商',domain="[('s_category_id','!=',False)]")
+    supplier_id = fields.Many2one('partner',u'供应商',domain=[('s_category_id','!=',False)])
     price = fields.Float(u'零售价')
     barcode = fields.Char(u'条形码')
 

--- a/sell/models/sell_delivery.py
+++ b/sell/models/sell_delivery.py
@@ -361,6 +361,10 @@ class wh_move_line(models.Model):
                 else:
                     self.discount_rate = 0
 
+    def _delivery_get_price_and_tax(self):
+        self.tax_rate = self.env.user.company_id.output_tax_rate
+        self.price_taxed = self.goods_id.price
+
     @api.multi
     @api.onchange('goods_id', 'tax_rate')
     def onchange_goods_id(self):
@@ -370,7 +374,6 @@ class wh_move_line(models.Model):
             is_return = self.env.context.get('default_is_return')
             # 如果是销售发货单行 或 销售退货单行
             if (self.type == 'out' and not is_return) or (self.type == 'in' and is_return):
-                self.tax_rate = self.env.user.company_id.output_tax_rate
-                self.price_taxed = self.goods_id.price
+                self._delivery_get_price_and_tax()
 
         return super(wh_move_line,self).onchange_goods_id()

--- a/sell/models/sell_order.py
+++ b/sell/models/sell_order.py
@@ -285,7 +285,10 @@ class sell_order(models.Model):
             'note': self.note,
             'discount_rate': self.discount_rate,
             'discount_amount': self.discount_amount,
-            'currency_id': self.currency_id.id
+            'currency_id': self.currency_id.id,
+            'contact': self.contact,
+            'address': self.address,
+            'mobile': self.mobile
         })
         if self.type == 'sell':
             delivery_id.write({'line_out_ids': [


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---


提交前:
---
订单审核时，生成的销货单，联系人、地址、电话为空

提交后:
---
订单审核时，生成的销货单，默认为订单中的数据

--
我确认贡献此代码版权给Gooderp项目
