### PR TITLE
修改商品单位 转化率 提示文字

### DIFF
--- a/core/models/goods.py
+++ b/core/models/goods.py
@@ -46,7 +46,7 @@ class goods(models.Model):
     uos_id = fields.Many2one('uom', ondelete='restrict', string=u'辅助单位')
     conversion = fields.Float(
         string=u'转化率', default=1, digits=(16, 3), 
-        help=u'1个辅助单位等于多少计量计量单位的数量，如1箱30个苹果，这里输入30')
+        help=u'1个辅助单位等于多少计量单位的数量，如1箱30个苹果，这里就输入30')
     cost = fields.Float(u'成本',
                         required=True,
                         digits=dp.get_precision('Amount'))


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---


提交前:
---
 help=u'1个辅助单位等于多少计量计量单位的数量，如1箱30个苹果，这里输入30')

提交后:
---
 help=u'1个辅助单位等于多少计量单位的数量，如1箱30个苹果，这里就输入30')

--
我确认贡献此代码版权给Gooderp项目
