### PR TITLE
所有系统的pivot视图的标签中必须要带有string 属性 不然会报错./

### DIFF
--- a/finance/report_auxiliary_accounting.xml
+++ b/finance/report_auxiliary_accounting.xml
@@ -21,7 +21,7 @@
             <field name='name'>report.auxiliary.accounting.graph</field>
             <field name='model'>report.auxiliary.accounting</field>
             <field name='arch' type='xml'>
-                <pivot>
+                <pivot string='辅助核算余额表'>
                     <field name='account_id' type='row'/>
                     <field name='auxiliary_id' type='col'/>
                     <field name='debit' type='measure'/>

--- a/sell/report/sell_order_detail_view.xml
+++ b/sell/report/sell_order_detail_view.xml
@@ -31,7 +31,7 @@
             <field name="name">sell.order.detail.graph</field>
             <field name="model">sell.order.detail</field>
             <field name="arch" type="xml">
-                <pivot>
+                <pivot string="销售明细表">
                     <field name='goods_id' type='row'/>
                     <field name='warehouse_id' type='col'/>
                     <field name='qty' type='measure' />

--- a/warehouse/report/lot_status_view.xml
+++ b/warehouse/report/lot_status_view.xml
@@ -43,7 +43,7 @@
             <field name='name'>report.lot.status.graph</field>
             <field name='model'>report.lot.status</field>
             <field name='arch' type='xml'>
-                <pivot>
+                <pivot string='批号状态表'>
                     <field name='lot' type='row' groups='goods.batch_groups' />
                     <field name='goods' type='row' />
                     <field name='warehouse' type='col' groups='warehouse.multi_warehouse_groups' />

--- a/warehouse/report/lot_track_view.xml
+++ b/warehouse/report/lot_track_view.xml
@@ -42,7 +42,7 @@
             <field name='name'>report.lot.track.graph</field>
             <field name='model'>report.lot.track</field>
             <field name='arch' type='xml'>
-                <pivot>
+                <pivot string="批号状态表">
                     <field name='lot' type='row' groups='goods.batch_groups' />
                     <field name='goods' type='row' />
                     <field name='warehouse' type='col' groups='warehouse.multi_warehouse_groups' />

--- a/warehouse/report/stock_balance_view.xml
+++ b/warehouse/report/stock_balance_view.xml
@@ -23,7 +23,7 @@
             <field name='name'>report.stock.balance.graph</field>
             <field name='model'>report.stock.balance</field>
             <field name='arch' type='xml'>
-                <pivot>
+                <pivot string="商品库存余额表">
                     <field name='goods' type='row' />
                     <field name='attribute_id' type='col' groups='goods.multi_attrs_groups' />
                     <field name='warehouse' type='col' groups='warehouse.multi_warehouse_groups' />

--- a/warehouse/report/stock_transceive_view.xml
+++ b/warehouse/report/stock_transceive_view.xml
@@ -49,7 +49,7 @@
             <field name='name'>report.stock.transceive.graph</field>
             <field name='model'>report.stock.transceive</field>
             <field name='arch' type='xml'>
-                <pivot>
+                <pivot string="商品收发明细表">
                     <field name='goods' type='row' />
                     <field name='warehouse' type='col' groups='warehouse.multi_warehouse_groups' />
                     <field name='goods_qty_begain' type='measure' />


### PR DESCRIPTION

![2016-11-24 11 59 09](https://cloud.githubusercontent.com/assets/13111533/20586321/f25cc716-b23d-11e6-98cc-53d353720c66.png)
本次提交合并增加的功能或解决的问题：
---  <pivot string="商品收发明细表">


提交前:
---


提交后:
---


--
我确认贡献此代码版权给GoodERP项目

