### PR TITLE
[FIX] 内部移库后，移出库的产品余额报表辅助数量为0

### DIFF
--- a/warehouse/goods.py
+++ b/warehouse/goods.py
@@ -123,8 +123,7 @@ class goods(models.Model):
                     break
 
                 matching_qty = min(line.qty_remaining, qty_to_go)
-                matching_uos_qty = line.qty_remaining == qty_to_go and \
-                    uos_qty_to_go or line.uos_qty_remaining
+                matching_uos_qty = matching_qty/goods.conversion
 
                 matching_records.append({'line_in_id': line.id,
                                          'qty': matching_qty, 'uos_qty': matching_uos_qty})


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---


提交前:
---
![wlj3iu vgoojdvlv4k _v](https://cloud.githubusercontent.com/assets/5688576/21009439/86728f00-bd81-11e6-8d89-3a057881fc0c.png)


提交后:
---
辅助数量显示正常

--
我确认贡献此代码版权给GoodERP项目

