### PR TITLE
web_export_view_good 报表模板菜单的新建．

### DIFF
--- a/web_export_view_good/view/web_export_view.xml
+++ b/web_export_view_good/view/web_export_view.xml
@@ -27,6 +27,7 @@
             <field name="view_type">form</field>
             <field name="view_mode">tree</field>
         </record>
-         <menuitem id='report_template_action_menu' action='report_template_action' parent='report.reporting_menuitem' sequence='10'/>
+         <menuitem id='report_excel_tempalte' parent="base.menu_custom" sequence='10' name="Excel报表模板"/>
+         <menuitem id='report_template_action_menu' action='report_template_action' parent="report_excel_tempalte" sequence='10'/>
     </data>
 </openerp>


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---
父菜单错误，还没依赖。

提交前:
---
提示：
ParseError: "External ID not found in the system: report.reporting_menuitem" while parsing /Users/mac/developWork/odoo/osbzr/gooderp_addons/web_export_view_good/view/web_export_view.xml:30, near 
```xml
<menuitem id="report_template_action_menu" action="report_template_action" parent="report.reporting_menuitem" sequence="10"/>
```
提交后:
---
bug fix

--
我确认贡献此代码版权给GoodERP项目
