### PR TITLE
	模块依赖错误,导致创建数据库时公司的 start_date 字段找不到

### DIFF
--- a/gooderp_statistics/__openerp__.py
+++ b/gooderp_statistics/__openerp__.py
@@ -11,7 +11,7 @@
         'views/web_need.xml',
     ],
     "depends":[
-        'web',
+        'core',
     ],
     'auto_install': True,
 }


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---


提交前:
---


提交后:
---


--
我确认贡献此代码版权给GoodERP项目
