### PR TITLE
修正固定表头js部分写法

### DIFF
--- a/fixed_header/static/src/js/fixed_header.js
+++ b/fixed_header/static/src/js/fixed_header.js
@@ -19,7 +19,7 @@ odoo.define('gooderp.fixed_header', function(require) {
                 }
             });
         },
-    })
+    });
 
     ListView.Groups.include({
         render_groups: function () {

--- a/fixed_header/static/src/js/fixed_header.js
+++ b/fixed_header/static/src/js/fixed_header.js
@@ -4,20 +4,20 @@ odoo.define('gooderp.fixed_header', function(require) {
     ListView.include({
         load_list: function () {
             var self = this;
-            this._super.apply(this, arguments);
-            var form_field_length = self.$el.parents('.o_form_field').length;
-            var scrollArea = $(".o_content")[0];
-            function do_freeze () {
-                self.$el.find('table.o_list_view').each(function () {
-                    $(this).stickyTableHeaders({scrollableArea: scrollArea});
-                });
-            }
+            return this._super.apply(this, arguments).done(function () {
+                var form_field_length = self.$el.parents('.o_form_field').length;
+                var scrollArea = $(".o_content")[0];
+                function do_freeze () {
+                    self.$el.find('table.o_list_view').each(function () {
+                        $(this).stickyTableHeaders({scrollableArea: scrollArea});
+                    });
+                }
 
-            if (form_field_length == 0) {
-                do_freeze();
-                $(window).unbind('resize', do_freeze).bind('resize', do_freeze);
-            }
-            return $.when();
+                if (form_field_length == 0) {
+                    do_freeze();
+                    $(window).unbind('resize', do_freeze).bind('resize', do_freeze);
+                }
+            });
         },
     })
 


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---
修正js：将执行锁定表头代码移至父类方法返回的promise对象的done回调匿名函数中。

提交前:
---
混动列表，可正常锁定表头；

提交后:
---
混动列表，可正常锁定表头，功能并无变化；

--
我确认贡献此代码版权给GoodERP项目
