### PR TITLE
购货订单支持按商品搜索

### DIFF
--- a/buy/models/buy_order.py
+++ b/buy/models/buy_order.py
@@ -85,6 +85,11 @@ class buy_order(models.Model):
             self.money_state = (self.type == 'buy') and u'全部付款' or u'全部退款'
         else:
             self.money_state = (self.type == 'buy') and u'部分付款' or u'部分退款'
+        
+    @api.depends('receipt_ids')
+    def _compute_receipt(self):
+        for order in self:
+            order.receipt_count = len(order.receipt_ids.ids)        
 
     partner_id = fields.Many2one('partner', u'供应商',
                                  states=READONLY_STATES,
@@ -183,7 +188,9 @@ class buy_order(models.Model):
                               compute=_get_money_state,
                               copy=False,
                               help=u'购货订单生成的采购入库单或退货单的付/退款状态')
-    goods_id = fields.Many2one('goods', related='line_ids.goods_id', string=u'商品')    
+    goods_id = fields.Many2one('goods', related='line_ids.goods_id', string=u'商品')
+    receipt_ids = fields.One2many('buy.receipt', 'order_id', string='Receptions', copy=False)
+    receipt_count = fields.Integer(compute='_compute_receipt', string='Receptions', default=0)
 
     @api.onchange('discount_rate', 'line_ids')
     def onchange_discount_rate(self):

--- a/buy/models/buy_order.py
+++ b/buy/models/buy_order.py
@@ -89,7 +89,14 @@ class buy_order(models.Model):
     @api.depends('receipt_ids')
     def _compute_receipt(self):
         for order in self:
-            order.receipt_count = len(order.receipt_ids.ids)        
+            order.receipt_count = len(order.receipt_ids.ids) 
+        
+    @api.depends('receipt_ids')
+    def _compute_invoice(self):
+        for order in self:
+            order.invoice_ids = order.receipt_ids.mapped('invoice_id')
+            order.invoice_count = len(order.invoice_ids.ids)			
+        
 
     partner_id = fields.Many2one('partner', u'供应商',
                                  states=READONLY_STATES,
@@ -190,7 +197,9 @@ class buy_order(models.Model):
                               help=u'购货订单生成的采购入库单或退货单的付/退款状态')
     goods_id = fields.Many2one('goods', related='line_ids.goods_id', string=u'商品')
     receipt_ids = fields.One2many('buy.receipt', 'order_id', string='Receptions', copy=False)
-    receipt_count = fields.Integer(compute='_compute_receipt', string='Receptions', default=0)
+    receipt_count = fields.Integer(compute='_compute_receipt', string='Receptions Count', default=0)
+    invoice_ids = fields.One2many('money.invoice', compute='_compute_invoice', string='Invoices')
+    invoice_count = fields.Integer(compute='_compute_invoice', string='Invoices Count', default=0)
 
     @api.onchange('discount_rate', 'line_ids')
     def onchange_discount_rate(self):
@@ -390,6 +399,68 @@ class buy_order(models.Model):
             'domain': [('id', '=', receipt_id)],
             'target': 'current',
         }
+
+    @api.multi
+    def action_view_receipt(self):
+        '''
+        This function returns an action that display existing picking orders of given purchase order ids.
+        When only one found, show the picking immediately.
+        '''
+		
+        self.ensure_one()
+        name = (self.type == 'buy' and u'采购入库单' or u'采购退货单')
+        action = {
+            'name': name,
+            'type': 'ir.actions.act_window',
+            'view_type': 'form',
+            'view_mode': 'form',
+            'res_model': 'buy.receipt',
+            'view_id': False,
+            'target': 'current',
+        }
+
+        #receipt_ids = sum([order.receipt_ids.ids for order in self], [])
+        receipt_ids = self.receipt_ids.ids
+        # choose the view_mode accordingly
+        if len(receipt_ids) > 1:
+            action['domain'] = "[('id','in',[" + ','.join(map(str, receipt_ids)) + "])]"
+            action['view_mode'] = 'tree'
+        elif len(receipt_ids) == 1:
+            view_id = (self.type == 'buy'
+                       and self.env.ref('buy.buy_receipt_form').id
+                       or self.env.ref('buy.buy_return_form').id)
+            action['views'] = [( view_id, 'form')]
+            action['res_id'] = receipt_ids and receipt_ids[0] or False
+        return action
+
+    @api.multi
+    def action_view_invoice(self):
+        '''
+        This function returns an action that display existing invoices of given purchase order ids( linked/computed via buy.receipt).
+        When only one found, show the invoice immediately.
+        '''
+		
+        self.ensure_one()
+        if self.invoice_count == 0:
+            return False
+        action = {
+            'name': u'结算单（供应商发票）',
+            'type': 'ir.actions.act_window',
+            'view_type': 'form',
+            'view_mode': 'form',
+            'res_model': 'money.invoice',
+            'view_id': False,
+            'target': 'current',
+        }
+        invoice_ids = self.invoice_ids.ids
+        # choose the view_mode accordingly
+        if len(invoice_ids) > 1:
+            action['domain'] = "[('id','in',[" + ','.join(map(str, invoice_ids)) + "])]"
+            action['view_mode'] = 'tree'
+        elif len(invoice_ids) == 1:            
+            action['views'] = [( False, 'form')]
+            action['res_id'] = invoice_ids and invoice_ids[0] or False
+        return action		
 
 
 class buy_order_line(models.Model):

--- a/buy/models/buy_order.py
+++ b/buy/models/buy_order.py
@@ -424,7 +424,7 @@ class buy_order(models.Model):
         # choose the view_mode accordingly
         if len(receipt_ids) > 1:
             action['domain'] = "[('id','in',[" + ','.join(map(str, receipt_ids)) + "])]"
-            action['view_mode'] = 'tree'
+            action['view_mode'] = 'tree,form'
         elif len(receipt_ids) == 1:
             view_id = (self.type == 'buy'
                        and self.env.ref('buy.buy_receipt_form').id

--- a/buy/models/buy_order.py
+++ b/buy/models/buy_order.py
@@ -183,6 +183,7 @@ class buy_order(models.Model):
                               compute=_get_money_state,
                               copy=False,
                               help=u'购货订单生成的采购入库单或退货单的付/退款状态')
+    goods_id = fields.Many2one('goods', related='line_ids.goods_id', string=u'商品')    
 
     @api.onchange('discount_rate', 'line_ids')
     def onchange_discount_rate(self):

--- a/buy/views/buy_order_view.xml
+++ b/buy/views/buy_order_view.xml
@@ -117,6 +117,7 @@
 					<field name="name"/>
 					<field name="type"/>
 					<field name="partner_id"/>
+					<field name="goods_id"/>
 					<field name="state"/>
 					<field name="goods_state"/>
 					<field name="create_uid" string="制单人"/>

--- a/buy/views/buy_order_view.xml
+++ b/buy/views/buy_order_view.xml
@@ -79,6 +79,35 @@
 								<field name="origin" invisible="1"/>
 								<field name='using_attribute' invisible='1'/>
 							</tree>
+							<form string="Purchase Order Line">
+								<sheet>
+									<group>
+										<group>
+											<field name="goods_id" required='1'/>
+											<field name="attribute_id"
+											groups='goods.multi_attrs_groups'
+											attrs="{'required': [('using_attribute','=', True)], 'readonly': [('using_attribute','!=', True)],
+											        'invisible': [('using_attribute','=', True)]}"/>
+											<field name="quantity" sum="合计数量"/>
+											<field name="quantity_in" readonly="1" sum="合计已入库数量"/>
+											<field name="uom_id"/>
+										</group>
+										<group>
+											<field name="price"/>
+											<field name="price_taxed" groups='buy.in_tax_groups'/>
+											<field name="discount_rate" groups='buy.buy_line_discount_groups'/>
+											<field name="discount_amount" sum="合计折扣额" groups='buy.buy_line_discount_groups'/>
+											<field name="amount" sum="合计金额"/>
+											<field name="tax_rate" groups='buy.in_tax_groups'/>
+											<field name="tax_amount" sum="合计税额" groups='buy.in_tax_groups'/>
+											<field name="subtotal" sum="价税合计的合计" groups='buy.in_tax_groups'/>
+										</group>
+										<field name="note"/>
+										<field name="origin" invisible="1"/>
+										<field name='using_attribute' invisible='1'/>
+									</group>
+								</sheet>
+							</form>
 						</field>
 						<field name="pay_ids" attrs="{'invisible': [('invoice_by_receipt','=',True)]}">
 							<tree string="Payment Form" editable="bottom" >

--- a/buy/views/buy_order_view.xml
+++ b/buy/views/buy_order_view.xml
@@ -85,36 +85,7 @@
 								<field name="note"/>
 								<field name="origin" invisible="1"/>
 								<field name='using_attribute' invisible='1'/>
-							</tree>
-							<form string="Purchase Order Line">
-								<sheet>
-									<group>
-										<group>
-											<field name="goods_id" required='1'/>
-											<field name="attribute_id"
-											groups='goods.multi_attrs_groups'
-											attrs="{'required': [('using_attribute','=', True)], 'readonly': [('using_attribute','!=', True)],
-											        'invisible': [('using_attribute','=', True)]}"/>
-											<field name="quantity" sum="合计数量"/>
-											<field name="quantity_in" readonly="1" sum="合计已入库数量"/>
-											<field name="uom_id"/>
-										</group>
-										<group>
-											<field name="price"/>
-											<field name="price_taxed" groups='buy.in_tax_groups'/>
-											<field name="discount_rate" groups='buy.buy_line_discount_groups'/>
-											<field name="discount_amount" sum="合计折扣额" groups='buy.buy_line_discount_groups'/>
-											<field name="amount" sum="合计金额"/>
-											<field name="tax_rate" groups='buy.in_tax_groups'/>
-											<field name="tax_amount" sum="合计税额" groups='buy.in_tax_groups'/>
-											<field name="subtotal" sum="价税合计的合计" groups='buy.in_tax_groups'/>
-										</group>
-										<field name="note"/>
-										<field name="origin" invisible="1"/>
-										<field name='using_attribute' invisible='1'/>
-									</group>
-								</sheet>
-							</form>
+							</tree>							
 						</field>
 						<field name="pay_ids" attrs="{'invisible': [('invoice_by_receipt','=',True)]}">
 							<tree string="Payment Form" editable="bottom" >

--- a/buy/views/buy_order_view.xml
+++ b/buy/views/buy_order_view.xml
@@ -44,7 +44,7 @@
 							<button type="object"
 								name="action_view_invoice"
 								class="oe_stat_button"
-								icon="fa-truck" attrs="{'invisible':['|', ('state', 'in', ('draft')),('invoice_count','=',0)]}">
+								icon="fa-pencil-square-o" attrs="{'invisible':['|', ('state', 'in', ('draft')),('invoice_count','=',0)]}">
 								<field name="invoice_count" widget="statinfo" string="结算单" help="Vendor Invoice"/>
 								<field name="invoice_ids" invisible="1"/>
 							</button>

--- a/buy/views/buy_order_view.xml
+++ b/buy/views/buy_order_view.xml
@@ -33,6 +33,15 @@
 						<field name="state" widget="statusbar" statusbar_visible="draft,done" statusbar_colors='{"done":"blue"}' readonly="1"/>
 					</header>
 					<sheet>
+						<div class="oe_button_box" name="button_box">
+							<button type="object"
+								name="action_view_receipt"
+								class="oe_stat_button"
+								icon="fa-truck" attrs="{'invisible':[('state', 'in', ('draft')),('receipt_ids','=',[])]}">
+								<field name="receipt_count" widget="statinfo" string="Shipment" help="Incoming Shipments"/>
+								<field name="receipt_ids" invisible="1"/>
+							</button>
+						</div>
 						<group>
 							<group>
 								<field name="partner_id" required="1"
@@ -131,6 +140,8 @@
 					<separator/>
 					<filter name="buy" string="购货" domain="[('type','=','buy')]"/>
 					<filter name="return" string="退货" domain="[('type','=','return')]"/>
+					<separator/>
+					<filter name="createby" string="我创建的" domain="[('create_uid', '=' ,uid)]"/>
 					<group expand="0" string="分组">
 						<filter string="供应商" domain="[]" context="{'group_by':'partner_id'}"/>
 						<filter string="单据日期" domain="[]" context="{'group_by':'date:day'}"/>

--- a/buy/views/buy_order_view.xml
+++ b/buy/views/buy_order_view.xml
@@ -37,9 +37,16 @@
 							<button type="object"
 								name="action_view_receipt"
 								class="oe_stat_button"
-								icon="fa-truck" attrs="{'invisible':[('state', 'in', ('draft')),('receipt_ids','=',[])]}">
-								<field name="receipt_count" widget="statinfo" string="Shipment" help="Incoming Shipments"/>
+								icon="fa-truck" attrs="{'invisible':['|', ('state', 'in', ('draft')),('receipt_count','=',0)]}">
+								<field name="receipt_count" widget="statinfo" string="入库/退货单" help="Incoming Shipments"/>
 								<field name="receipt_ids" invisible="1"/>
+							</button>
+							<button type="object"
+								name="action_view_invoice"
+								class="oe_stat_button"
+								icon="fa-truck" attrs="{'invisible':['|', ('state', 'in', ('draft')),('invoice_count','=',0)]}">
+								<field name="invoice_count" widget="statinfo" string="结算单" help="Vendor Invoice"/>
+								<field name="invoice_ids" invisible="1"/>
 							</button>
 						</div>
 						<group>


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---


提交前:
---


提交后:
---
在购货订单清单界面的右上角可以输入商品编号或名称，选择商品搜索项，即可以将包含此商品的购货订单筛选出来。
再次以高级搜索的方式，搜索另一个商品，系统会将两次搜索作并集（and)处理，也就是说可以搜出同时包含了这两个不同商品的订单！这种用法很有意义。

--
我确认贡献此代码版权给GoodERP项目
