### PR TITLE
[FIX]修复实际上仓库中该产品充足但移库单、其他出库单等的出库明细行上产品批号下拉为空的问题

### DIFF
--- a/buy/views/buy_receipt_view.xml
+++ b/buy/views/buy_receipt_view.xml
@@ -85,7 +85,7 @@
 				 					<field name='cost_unit' groups='goods.view_cost_groups'/>
 		                            <field name="discount_rate" groups='buy.buy_line_discount_groups'/>
 		                            <field name="discount_amount" groups='buy.buy_line_discount_groups' readonly="0" sum="合计折扣额"/>
-		                            <field name="amount" string="购货金额" sum="合计金额"/>
+		                            <field name="amount" string="购货金额" sum="合计金额" groups='goods.view_cost_groups'/>
 		                            <field name="tax_rate" groups='buy.in_tax_groups'/>
 		                            <field name="tax_amount" sum="合计税额" groups='buy.in_tax_groups'/>
 		                            <field name="subtotal" sum="价税合计的合计" groups='buy.in_tax_groups'/>

--- a/sell/models/sell_delivery.py
+++ b/sell/models/sell_delivery.py
@@ -467,3 +467,5 @@ class wh_move_line(models.Model):
             # 如果是销售发货单行 或 销售退货单行
             if (self.type == 'out' and not is_return) or (self.type == 'in' and is_return):
                 self._delivery_get_price_and_tax()
+
+        return super(wh_move_line, self).onchange_goods_id()

--- a/sell/views/sell_view.xml
+++ b/sell/views/sell_view.xml
@@ -420,7 +420,7 @@
 				 						<field name='cost_unit' groups='goods.view_cost_groups'/>
 										<field name='discount_rate' groups='sell.sell_line_discount_groups'/>
 										<field name='discount_amount' sum='折扣额合计' groups='sell.sell_line_discount_groups'/>
-				 						<field name='amount' string='销售金额' sum='金额合计'/>
+				 						<field name='amount' string='销售金额' sum='金额合计' groups='goods.view_cost_groups'/>
 				 						<field name='tax_rate' groups='sell.out_tax_groups'/>
 		         						<field name='tax_amount' sum='税额合计' groups='sell.out_tax_groups'/>
 				 						<field name='subtotal' sum='价税合计' groups='sell.out_tax_groups'/>


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---
实际上仓库中该产品充足，但移库单、其他出库单等的出库明细行上产品批号下拉为空

提交前:
---
实际上仓库中该产品充足，但移库单、其他出库单等的出库明细行上产品批号下拉为空

提交后:
---
实际上仓库中该产品充足，移库单、其他出库单等的出库明细行上产品批号可查看

--
我确认贡献此代码版权给GoodERP项目
