### PR TITLE
[FIX]继续修改ISSUE #1113：收付款单审核和反审核时都应该保持待核销行中金额、已核销金额、未核销金额不变

### DIFF
--- a/money/money_order.py
+++ b/money/money_order.py
@@ -248,11 +248,8 @@ class money_order(models.Model):
                     raise UserError(u'本次核销金额不能大于未核销金额!\n 核销金额:%s 未核销金额:%s'
                                     %(abs(source.to_reconcile),source.this_reconcile))
 
-                source.to_reconcile = (source.to_reconcile - 
-                                       source.this_reconcile)
-                source.reconciled += source.this_reconcile
-                source.name.to_reconcile = source.to_reconcile
-                source.name.reconciled = source.reconciled
+                source.name.to_reconcile -= source.this_reconcile
+                source.name.reconciled += source.this_reconcile
 
             order.state = 'done'
         return True
@@ -280,10 +277,8 @@ class money_order(models.Model):
                 order.partner_id.receivable += total + self.discount_amount
 
             for source in order.source_ids:
-                source.reconciled -= source.this_reconcile
-                source.to_reconcile += source.this_reconcile
-                source.name.to_reconcile = source.to_reconcile
-                source.name.reconciled = source.reconciled
+                source.name.to_reconcile += source.this_reconcile
+                source.name.reconciled -= source.this_reconcile
 
             order.state = 'draft'
         return True


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---


提交前:
---


提交后:
---


--
我确认贡献此代码版权给GoodERP项目
