### PR TITLE
仪表板列表右上角增加跳转至原始列表视图的按钮

### DIFF
--- a/web_dashboard_open_action/README.rst
+++ b/web_dashboard_open_action/README.rst
@@ -1,0 +1,39 @@
+Open a dashboard's action
+=========================
+
+This module adds a button to open a dashboard's action in the usual view, thus enabling filtering and any other actions you can apply on the resulting records. Basically, this is the inverso to `Add to dashboard`.
+
+Usage
+=====
+
+After installation, a dashboard has a `Maximize`-button that loads the dashboard's action in a normal view.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/web/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/web/issues/new?body=module:%20web_dashboard_open_action%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Holger Brunn <hbrunn@therp.nl>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+    :alt: Odoo Community Association
+    :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/web_dashboard_open_action/__init__.py
+++ b/web_dashboard_open_action/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2015 Therp BV <http://therp.nl>.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################

--- a/web_dashboard_open_action/__manifest__.py
+++ b/web_dashboard_open_action/__manifest__.py
@@ -1,0 +1,44 @@
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2015 Therp BV <http://therp.nl>.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Open a dashboard's action",
+    "version": "10.0.1.0.0",
+    "author": "Therp BV,Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "category": "Hidden",
+    "summary": "Adds a button to open a dashboard in full mode",
+    "depends": [
+        'board',
+    ],
+    "data": [
+        'views/templates.xml',
+    ],
+    "qweb": [
+        'static/src/xml/web_dashboard_open_action.xml',
+    ],
+    "test": [
+    ],
+    "auto_install": False,
+    'installable': True,
+    "application": False,
+    "external_dependencies": {
+        'python': [],
+    },
+}

--- a/web_dashboard_open_action/static/src/css/web_dashboard_open_action.css
+++ b/web_dashboard_open_action/static/src/css/web_dashboard_open_action.css
@@ -1,0 +1,7 @@
+.oe_dashboard .oe_action span.oe_web_dashboard_open_action:before
+{
+    font-size: 10px;
+    margin-left: 4px;
+    position: relative;
+    top: -1px;
+}

--- a/web_dashboard_open_action/static/src/js/web_dashboard_open_action.js
+++ b/web_dashboard_open_action/static/src/js/web_dashboard_open_action.js
@@ -1,0 +1,48 @@
+//-*- coding: utf-8 -*-
+//############################################################################
+//
+//   OpenERP, Open Source Management Solution
+//   This module copyright (C) 2015 Therp BV <http://therp.nl>.
+//
+//   This program is free software: you can redistribute it and/or modify
+//   it under the terms of the GNU Affero General Public License as
+//   published by the Free Software Foundation, either version 3 of the
+//   License, or (at your option) any later version.
+//
+//   This program is distributed in the hope that it will be useful,
+//   but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//   GNU Affero General Public License for more details.
+//
+//   You should have received a copy of the GNU Affero General Public License
+//   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+//############################################################################
+
+odoo.define('web_dashboard_open_action', function (require) {
+    "use strict";
+    var core = require('web.core');
+    var pyeval = require('web.pyeval');
+
+    core.form_tag_registry.get('board').include({
+        on_load_action: function(result, index, action_attrs)
+        {
+            var self = this, action = _.extend({flags: {}}, result);
+            action.context_string = action_attrs.context;
+            action.domain_string = action_attrs.domain;
+            action.context = pyeval.eval(
+                'contexts', [action.context || {}, action_attrs.context || {}]);
+            action.domain = pyeval.eval(
+                'domains', [action_attrs.domain || [], action.domain || []],
+                action.context);
+            jQuery('#' + this.view.element_id + '_action_' + index)
+                .parent()
+                .find('.oe_web_dashboard_open_action')
+                .click(function()
+                {
+                    self.do_action(action);
+                });
+            return this._super.apply(this, arguments);
+        },
+    });
+})

--- a/web_dashboard_open_action/static/src/xml/web_dashboard_open_action.xml
+++ b/web_dashboard_open_action/static/src/xml/web_dashboard_open_action.xml
@@ -1,0 +1,7 @@
+<templates>
+    <t t-extend="DashBoard.action">
+        <t t-jquery="span.oe_minimize" t-operation="after">
+            <span class="oe_icon oe_web_dashboard_open_action fa fa-arrows-alt" />
+        </t>
+    </t>
+</templates>

--- a/web_dashboard_open_action/views/templates.xml
+++ b/web_dashboard_open_action/views/templates.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <template id="assets_backend" name="web_dashboard_open_action assets" inherit_id="web.assets_backend">
+            <xpath expr="." position="inside">
+                <script type="text/javascript" src="/web_dashboard_open_action/static/src/js/web_dashboard_open_action.js"></script>
+                <link rel="stylesheet" href="/web_dashboard_open_action/static/src/css/web_dashboard_open_action.css"/>
+            </xpath>
+        </template>
+    </data>
+</openerp>


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
仪表板中的列表没有直接跳转回原列表视图的功能，如果需要修改过滤选项或者回到原列表视图需要再通过主页或APP菜单路径跳转。



提交前:
---


提交后:
---
在仪表板的每个列表区块右上角最小化按钮左边增加一个最大化按钮，点击此按钮即可直接跳转至原列表视图。

--
我确认贡献此代码版权给GoodERP项目
