### PR TITLE
bugfix 审批过程中点击‘拒绝’按钮报js错误

### DIFF
--- a/good_process/static/src/js/good_process.js
+++ b/good_process/static/src/js/good_process.js
@@ -46,7 +46,7 @@ odoo.define('good.process', function(require) {
                     if (result[0] && typeof(result[0]) == 'object') {
                         self.render_tag(result[0]);
                         if (result[1]) {
-                            self.send_message(message)
+                            self.send_message(result[1])
                         }
 
                     } else {


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：审批过程中点击‘拒绝’按钮报js错误
---


提交前:
---
Uncaught ReferenceError: message is not defined
http://127.0.0.1:8066/good_process/static/src/js/good_process.js:49
回溯:
ReferenceError: message is not defined
    at Object.<anonymous> (http://127.0.0.1:8066/good_process/static/src/js/good_process.js:49:47)
    at Object.<anonymous> (http://127.0.0.1:8066/web/static/lib/jquery/jquery.js:3276:89)
    at fire (http://127.0.0.1:8066/web/static/lib/jquery/jquery.js:3119:58)
    at Object.fireWith [as resolveWith] (http://127.0.0.1:8066/web/static/lib/jquery/jquery.js:3231:49)
    at Object.deferred.(anonymous function) (http://127.0.0.1:8066/web/static/lib/jquery/jquery.js:3321:62)
    at fire (http://127.0.0.1:8066/web/static/lib/jquery/jquery.js:3119:58)
    at Object.fireWith [as resolveWith] (http://127.0.0.1:8066/web/static/lib/jquery/jquery.js:3231:49)
    at Object.<anonymous> (http://127.0.0.1:8066/web/static/lib/jquery/jquery.js:3283:104)
    at fire (http://127.0.0.1:8066/web/static/lib/jquery/jquery.js:3119:58)
    at Object.fireWith [as resolveWith] (http://127.0.0.1:8066/web/static/lib/jquery/jquery.js:3231:49)

提交后:
---


--
我确认贡献此代码版权给GoodERP项目
