### PR TITLE
[FIX] 修复打印拣货单，按格子号排序了，但是商品数量没有排序的bug

### DIFF
--- a/warehouse_wave/report/report.xml
+++ b/warehouse_wave/report/report.xml
@@ -64,7 +64,7 @@
 												</t>
 	                						</td>
 	                						<td>
-	                							<t t-foreach="l.move_line_ids" t-as="move_line">
+												<t t-foreach="l.move_line_ids.sorted(key=lambda x: x.move_id.pakge_sequence)" t-as="move_line">
 	                								<span t-field="move_line.goods_qty"/><br/>
 												</t>
 	                						</td>


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---


提交前:
---


提交后:
---


--
我确认贡献此代码版权给GoodERP项目
