### PR TITLE
fix export money symbol

### DIFF
--- a/web_export_view_good/static/src/js/web_export_view_good.js
+++ b/web_export_view_good/static/src/js/web_export_view_good.js
@@ -44,7 +44,7 @@ function compute_main_data(rows,export_columns_keys){
                 var text = cell.text || cell.textContent || cell.innerHTML || "";
                 var is_boolean_cell = cell_object.find('.o_checkbox input[type=checkbox]');
                 if (cell.classList.contains("oe_list_field_float")||cell.classList.contains("o_list_number")||cell.classList.contains("oe_number")) {
-                    export_row.push(formats.parse_value(text, {'type': "float"}, 0));
+                    export_row.push(formats.parse_value(text.replace(/[^0-9.]/g, ''), {'type': "float"}, 0));
                 }else if (is_boolean_cell.length>0) {
                     if (is_boolean_cell.get(0).checked) {
                         export_row.push('√');


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---
解决导出Excel表格浮点数报错的问题
如果浮点数中包含货币符号，则会报错
```
Uncaught Error: '570.00 ¥' 不是正确的浮点数

http://localhost:8069/web/static/src/js/framework/formats.js:146
追溯:
Error: '570.00 ¥' 不是正确的浮点数
    at Object.parse_value (http://localhost:8069/web/static/src/js/framework/formats.js:146:23)
    at String.<anonymous> (http://localhost:8069/web_export_view_good/static/src/js/web_export_view_good.js:47:45)
    at Function.each (http://localhost:8069/web/static/lib/jquery/jquery.js:383:58)
    at HTMLTableRowElement.<anonymous> (http://localhost:8069/web_export_view_good/static/src/js/web_export_view_good.js:36:15)
    at Function.each (http://localhost:8069/web/static/lib/jquery/jquery.js:383:58)
    at compute_main_data (http://localhost:8069/web_export_view_good/static/src/js/web_export_view_good.js:29:7)
    at Class.button_export_action (http://localhost:8069/web_export_view_good/static/src/js/web_export_view_good.js:115:38)
    at HTMLDivElement.dispatch (http://localhost:8069/web/static/lib/jquery/jquery.js:4641:58)
    at HTMLDivElement.elemData.handle (http://localhost:8069/web/static/lib/jquery/jquery.js:4309:63)
```


提交前:
---


提交后:
---


--
我确认贡献此代码版权给GoodERP项目
