### PR TITLE
[FIX]采购、销售订单反审核时重新加入审批流程，及解决反审核入库单报错的bug

### DIFF
--- a/buy/models/buy_order.py
+++ b/buy/models/buy_order.py
@@ -344,10 +344,8 @@ class BuyOrder(models.Model):
             if self.money_order_id.state == 'done':
                 self.money_order_id.money_order_draft()
             self.money_order_id.unlink()
-        self.write({
-            'approve_uid': '',
-            'state': 'draft',  # 为保证审批流程顺畅，否则，未审批就可审核
-        })
+        self.approve_uid = ''
+        self.state = 'draft'
 
     @api.one
     def get_receipt_line(self, line, single=False):

--- a/good_process/models/mail_thread.py
+++ b/good_process/models/mail_thread.py
@@ -199,7 +199,7 @@ class MailThread(models.AbstractModel):
             change_state = vals.get('state', False)
 
             # 已提交，确认时报错
-            if len(th._to_approver_ids) == th._approver_num and change_state:
+            if len(th._to_approver_ids) == th._approver_num and change_state == 'done':
                 raise ValidationError(u"审批后才能确认")
             # 已审批
             if not len(th._to_approver_ids):

--- a/sell/models/sell_order.py
+++ b/sell/models/sell_order.py
@@ -314,10 +314,8 @@ class SellOrder(models.Model):
         if self.money_order_id:
             self.money_order_id.money_order_draft()
             self.money_order_id.unlink()
-        self.write({
-            'approve_uid': '',
-            'state': 'draft',  # 为保证审批流程顺畅，否则，未审批就可审核
-        })
+        self.approve_uid = ''
+        self.state = 'draft'
 
     @api.one
     def get_delivery_line(self, line, single=False):


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---


提交前:
---
1 购货订单设置了审批流程， 购货订单反审核后不需要审批
2 入库单设置了审批流程，入库单反审核时报错“审批后才能确认”

提交后:
---
1 购货订单反审核后需要重新审批
2 入库单能够反审核

--
我确认贡献此代码版权给GoodERP项目
