### PR TITLE
修改主页关键指标中按钮的布局，使之对齐

### DIFF
--- a/home_page/static/src/js/home_page.js
+++ b/home_page/static/src/js/home_page.js
@@ -151,7 +151,7 @@ odoo.define('home_page', function (require) {
                     row_num = parseInt(12 / (result_top.length % 4)) == 0 ? 4 : parseInt(12 / (result_top.length % 4))
                 }
                 if (top_data.length == 2) {
-                    row_num = 1;
+                    //row_num = 1;
                     var left_html_str = $("<div class='col-xs-6 col-sm-" + row_num + " block-center text-center'>\
                           <button class='oe_top_link_" + i +
                         "' oe_top_link='" + i + "' id='" + i + "' style='width: 120px;height: 80px'>\


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---
修改主页关键指标中按钮的布局，使之对齐

提交前:
---
<img width="1179" alt="1" src="https://user-images.githubusercontent.com/9276549/40895328-5d39ef5a-67e1-11e8-9a81-b0f0754e47dc.png">

提交后:
---
<img width="1165" alt="2" src="https://user-images.githubusercontent.com/9276549/40895336-65612bd0-67e1-11e8-927d-a0438acc9015.png">

--
我确认贡献此代码版权给GoodERP项目