### PR TITLE
[IMP]属性名称里不显示属性类别

### DIFF
--- a/goods/models/goods.py
+++ b/goods/models/goods.py
@@ -117,7 +117,7 @@ class Attribute(models.Model):
     @api.depends('value_ids')
     def _compute_name(self):
         self.name = ' '.join(
-            [value.category_id.name + ':' + value.value_id.name for value in self.value_ids])
+            [value.value_id.name for value in self.value_ids])
 
     @api.model
     def name_search(self, name='', args=None, operator='ilike', limit=100):

--- a/goods/tests/test_goods.py
+++ b/goods/tests/test_goods.py
@@ -131,7 +131,7 @@ class TestAttributes(TransactionCase):
         iphone_value_white = self.env.ref('goods.iphone_value_white')
         result = self.env['attribute'].name_search('12345678987')
         real_result = [(iphone_value_white.id,
-                        iphone_value_white.category_id.name + ':' + iphone_value_white.value_id.name)]
+                        iphone_value_white.value_id.name)]
         self.assertEqual(result, real_result)
 
         # return super


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---
属性名称里不需要显示属性类别，以免冗余

提交前:
---
短袖衬衫 颜色：白 尺码：XL

提交后:
---
短袖衬衫 白 XL

--
我确认贡献此代码版权给GoodERP项目
