### PR TITLE
添加限制 已有核销金额的结算单不允许删除

### DIFF
--- a/goods/view/goods_view.xml
+++ b/goods/view/goods_view.xml
@@ -94,6 +94,7 @@
 					<field name='name'/>
 					<field name='brand'/>
 					<field name='code'/>
+					<field name='goods_class_id'/>
 					<field name='category_id'/>
 					<group expand="0" string="分组">
                         <filter string="商品类别" domain="[]" context="{'group_by':'category_id'}"/>

--- a/money/models/money_order.py
+++ b/money/models/money_order.py
@@ -723,6 +723,8 @@ class MoneyInvoice(models.Model):
         for inv in self:
             if inv.state == 'draft':
                 raise UserError(u'请不要重复撤销')
+            if inv.reconciled != 0.0:
+                raise UserError(u'已核销的结算单不允许删除')
             inv.reconciled = 0.0
             inv.to_reconcile = 0.0
             inv.state = 'draft'

--- a/money/models/money_order.py
+++ b/money/models/money_order.py
@@ -1158,6 +1158,7 @@ class ReconcileOrder(models.Model):
             invoices = self.env['money.invoice'].search([('name', '=', name)])
             for inv in invoices:
                 if inv.state == 'done':
+                    inv.reconciled = 0.0
                     inv.money_invoice_draft()
                 inv.unlink()
         return True


### PR DESCRIPTION
本次提交合并增加的功能或解决的问题：
---


提交前:
---
已有核销金额的采购入库单等可以被反审核，导致核销金额不对应等问题。

提交后:
---
已有核销金额的结算单不允许删除！

--
我确认贡献此代码版权给GoodERP项目

人生第一个提交  谢谢~！